### PR TITLE
포트폴리오를 CLI 스타일로 리디자인

### DIFF
--- a/src/app/career/page.tsx
+++ b/src/app/career/page.tsx
@@ -14,7 +14,7 @@ const careers = [
     period: "2020.12 ~ 현재",
     role: "UI 개발자",
     description:
-      "국내 주요 이커머스 서비스인 11번가에서 모바일웹 상품상세페이지(PDP)를 포함한 핵심 서비스 UI를 개발·운영하고 있습니다. SCSS→Dart Sass 전환(2,384개 파일), CSS 내재화, React 기반 환경 개선, Storybook 기반 UI 확인 환경처럼 오래 운영된 화면 구조와 스타일 관리 흐름을 단계적으로 정리했습니다. 최근에는 PDP ATF 영역 개선을 진행하며 초기 노출 화면의 UI 구조, 스타일 의존성, 변경 범위와 검증 기준을 점검하고 있습니다.",
+      "국내 주요 이커머스 서비스인 11번가에서 모바일웹 상품상세페이지(PDP)를 포함한 핵심 서비스 UI를 개발·운영하고 있습니다. SCSS→Dart Sass 전환(2,384개 파일), CSS 내재화, React 기반 환경 개선, Storybook 기반 UI 확인 환경을 통해 기존 화면 구조와 스타일 관리 흐름을 단계적으로 정리했습니다. 최근에는 PDP ATF 영역 개선을 진행하며 초기 노출 화면의 UI 구조, 스타일 의존성, 변경 범위와 검증 기준을 점검하고 있습니다.",
     projects: [
       { period: "2020.12 ~ 현재", title: "모바일웹 상품상세(PDP) 전체 UI 개발", link: "/tech/pdp-ui" },
       { period: "2026.07 ~ 현재", title: "PDP ATF 영역 개선 — React 환경 내 초기 노출 UI 구조 점검", link: "/tech/react-pdp" },
@@ -122,7 +122,7 @@ const keyDocs = [
 const sideProjects = [
   { title: "개인 서비스 구축·운영", stack: "Next.js · Supabase · Vercel · API Webhook", description: "작은 커머스/콘텐츠 서비스를 직접 만들고 배포하며 기획, 구현, 운영 피드백까지 경험하고 있습니다." },
   { title: "콘텐츠 자동화 파이프라인", stack: "Node.js · Google Apps Script · Gemini · GitHub", description: "키워드 수집, 콘텐츠 초안 생성, 블로그 PR 생성까지 이어지는 자동화 흐름을 운영하고 있습니다." },
-  { title: "AI 보조 개발 환경 실험", stack: "Claude Code · Codex · Obsidian RAG", description: "개인 지식 문서와 개발 도구를 연결해 문서 검색, 작업 정리, 코드 변경 보조 흐름을 실험하고 있습니다." },
+  { title: "AI 보조 개발 환경", stack: "Claude Code · Codex · Obsidian RAG", description: "개인 지식 문서와 개발 도구를 연결해 문서 검색, 작업 기록, 코드 변경 보조 흐름을 운영하고 있습니다." },
 ];
 
 export default function CareerPage() {
@@ -142,9 +142,9 @@ export default function CareerPage() {
       <section className="mb-12">
         <h2 className="mb-4 text-xs font-semibold uppercase tracking-widest text-[var(--color-muted)]">About</h2>
         <div className="space-y-3 text-sm text-[var(--color-muted)] leading-relaxed">
-          <p>커머스, 게임, 플랫폼 서비스에서 UI 개발과 운영을 해왔습니다. 웹 표준, 접근성, 마크업 구조화, SCSS 설계, 반응형 UI 구현을 바탕으로 오래 운영되는 웹·모바일 서비스의 화면 구조와 유지보수성을 개선해왔습니다.</p>
+          <p>커머스, 게임, 플랫폼 서비스에서 UI 개발과 운영을 해왔습니다. 웹 표준, 접근성, 마크업 구조화, SCSS 설계, 반응형 UI 구현을 바탕으로 운영 중인 웹·모바일 서비스의 화면 구조와 유지보수성을 개선해왔습니다.</p>
           <p>현재는 11번가에서 모바일웹 상품상세(PDP)를 포함한 핵심 서비스 UI를 담당하고 있습니다. HTML/SCSS 기반 산출물을 React 기반 환경으로 옮기고, CSS 내재화와 Storybook 기반 UI 확인 환경을 통해 화면 코드와 스타일 변경 맥락을 함께 관리하는 구조를 정리하고 있습니다.</p>
-          <p>하이브랩에서는 약 3년간 팀장으로 업무 분배, 공수 산정, 클라이언트 커뮤니케이션, 팀원 온보딩과 품질 관리를 담당했습니다. 최근에는 PR 리뷰, 문서화, QA 체크리스트처럼 반복되는 개발 흐름에 AI 보조 도구를 적용해 사람이 검토할 초안과 기준을 만드는 방식도 함께 실험하고 있습니다.</p>
+          <p>하이브랩에서는 약 3년간 팀장으로 업무 분배, 공수 산정, 클라이언트 커뮤니케이션, 팀원 온보딩과 품질 관리를 담당했습니다. 최근에는 PR 리뷰, 문서화, QA 체크리스트처럼 반복되는 개발 흐름에 AI 보조 도구를 적용하고, 팀에서 재사용할 수 있는 규칙과 산출물 형식을 정리하고 있습니다.</p>
         </div>
       </section>
 
@@ -208,7 +208,7 @@ export default function CareerPage() {
       <section className="mb-12">
         <h2 className="mb-2 text-xs font-semibold uppercase tracking-widest text-[var(--color-muted)]">Key Documents</h2>
         <p className="mb-6 text-xs text-[var(--color-muted)]">
-          문제 해결, 기술 검토, 경험 공유를 목적으로 직접 작성한 핵심 문서입니다. Confluence 위키에 <strong className="text-[var(--color-foreground)]">70여 건</strong>을 작성했으며, 그 중 주요 문서를 정리했습니다.
+          문제 해결, 기술 검토, 경험 공유를 목적으로 직접 작성한 문서 중 주요 내용을 정리했습니다.
         </p>
         <div className="space-y-8">
           {keyDocs.map((group) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,8 +30,8 @@ const highlights = [
     description: "모바일웹 핵심 화면을 운영하며 가격, 옵션, 리뷰, 배송처럼 여러 도메인의 영향 범위와 검증 기준을 맞춰 개발합니다.",
   },
   {
-    title: "오래된 UI 구조 개선",
-    description: "Dart Sass 전환, CSS 내재화, React 환경 개선으로 오래 운영된 화면 구조와 스타일 관리 흐름을 단계적으로 정리했습니다.",
+    title: "기존 UI 구조 개선",
+    description: "Dart Sass 전환, CSS 내재화, React 환경 개선으로 화면 구조와 스타일 관리 흐름을 단계적으로 정리했습니다.",
   },
   {
     title: "UI 품질과 협업 기준",
@@ -63,7 +63,7 @@ export default async function Home() {
         <h1 className="text-3xl font-bold tracking-tight mb-4">김성재</h1>
         <p className="text-sm text-[var(--color-muted)] leading-relaxed max-w-xl">
           커머스, 게임, 플랫폼 서비스에서 UI 개발과 운영을 해왔습니다.
-          웹 표준, 접근성, 마크업 구조화, SCSS 설계, 반응형 UI 구현을 바탕으로 오래 운영되는 서비스 화면의 구조와 유지보수성을 개선해왔습니다.
+          웹 표준, 접근성, 마크업 구조화, SCSS 설계, 반응형 UI 구현을 바탕으로 운영 중인 서비스 화면의 구조와 유지보수성을 개선해왔습니다.
           최근에는 HTML/SCSS 중심 산출물을 React 기반 환경으로 옮기고, Storybook·문서화·리뷰 기준을 통해 컴포넌트 단위 검증과 협업 흐름을 정리하고 있습니다.
         </p>
         <div className="mt-6 flex flex-wrap gap-3">

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -2,59 +2,81 @@ import "./portfolio.css";
 
 export default function PortfolioPage() {
   return (
-    <>
+    <div className="pf-workspace">
+      <header className="pf-cli-header">
+        <a className="pf-cli-brand" href="#top" aria-label="포트폴리오 처음으로">
+          <span aria-hidden="true">&gt;_</span> k.sungjae@portfolio:~$
+        </a>
+        <nav className="pf-cli-nav" aria-label="포트폴리오 탐색">
+          <a href="#top">About</a>
+          <a href="#work">Experience</a>
+          <a href="#case-study">Case Study</a>
+          <a href="#experiments">Experiments</a>
+          <a href="#writing">Writing</a>
+          <a href="mailto:k.suzkim@gmail.com">Contact</a>
+        </nav>
+        <p className="pf-cli-status"><i aria-hidden="true" /> UI / Frontend</p>
+      </header>
+
+      <main className="pf-main">
+
       {/* HERO */}
-      <div className="pf-hero">
-        <h1>김성재</h1>
-        <p className="pf-hero-desc">
-          커머스, 게임, 플랫폼 서비스에서 UI 개발과 운영을 해왔습니다.
-          웹 표준, 접근성, 마크업 구조화, SCSS 설계, 반응형 UI 구현을 바탕으로
-          오래 운영되는 서비스 화면의 구조와 유지보수성을 개선해왔습니다.
-          <br /><br />
-          현재는 모바일웹 상품상세처럼 여러 도메인이 맞물리는 화면을 운영하며,
-          HTML/SCSS 기반 산출물을 React 환경으로 옮기고 CSS 의존성을 프로젝트 안으로 정리하는 일을 하고 있습니다.
-          <br />
-          Storybook, 문서화, 리뷰 기준을 통해 컴포넌트 단위로 확인 가능한 협업 흐름을 만드는 데도 집중하고 있습니다.
-          <br /><br />
-          AI 도구는 전면에 세우기보다 반복 리뷰, 문서 초안, QA 체크리스트처럼
-          사람이 검토할 초안을 만드는 보조 흐름으로 다룹니다.
-          <br />
-          제가 보고 싶은 결과는 새 도구 도입 자체가 아니라, 화면을 더 안전하게 바꾸고 검증하는 흐름입니다.
-        </p>
-      </div>
-
-      <hr className="pf-divider" />
-
-      {/* 포커스 */}
-      <section className="pf-section">
-        <h2 className="pf-section-title">요즘 집중하는 것</h2>
-        <div className="pf-focus-grid">
-          <div className="pf-focus-card">
-            <h3>화면 구조와 영향 범위 보기</h3>
-            <p>
-              PDP처럼 여러 도메인이 맞물리는 화면에서 무엇이 바뀌고 어디까지 확인해야 하는지 먼저 나누는 데 집중합니다.
-            </p>
-          </div>
-          <div className="pf-focus-card">
-            <h3>컴포넌트 단위로 확인하기</h3>
-            <p>
-              Storybook과 문서화를 통해 기획, 디자인, 개발이 같은 화면 상태를 보고 이야기할 수 있게 정리합니다.
-            </p>
-          </div>
-          <div className="pf-focus-card">
-            <h3>반복 확인을 줄이는 흐름 만들기</h3>
-            <p>
-              리뷰 기준, 작업 정리, QA 체크리스트처럼 매번 반복되는 확인 항목을 검토 가능한 초안으로 만듭니다.
-            </p>
-          </div>
+      <header className="pf-hero" id="top">
+        <div className="pf-hero-meta">
+          <span>README.md / profile</span>
+          <span><i aria-hidden="true" /> updated · 2026</span>
         </div>
+        <p className="pf-hero-command"><span aria-hidden="true">$</span> whoami</p>
+        <h1>김성재</h1>
+        <p className="pf-hero-statement">
+          서비스 UI를 오래<br className="pf-break-mobile" />{" "}
+          운영하고,<br className="pf-break-desktop" />{" "}
+          더<br className="pf-break-mobile" />{" "}
+          안전하게 바꿉니다.
+        </p>
+        <div className="pf-hero-status" aria-label="핵심 역할과 경험">
+          <p><span>role</span><strong>UI / Frontend Developer</strong></p>
+          <p><span>scope</span><strong>모바일웹 PDP 운영</strong></p>
+          <p><span>migration</span><strong>2,384 SCSS · React 환경 이관</strong></p>
+        </div>
+        <a className="pf-scroll-link" href="#work"><span aria-hidden="true">$</span> open ./work <span aria-hidden="true">↓</span></a>
+      </header>
+
+      <section className="pf-readme-output" aria-label="포트폴리오 소개">
+        <div className="pf-readme-header">
+          <span>README.md</span>
+          <span>3 blocks</span>
+        </div>
+        <div className="pf-hero-copy">
+          <p>
+            커머스, 게임, 플랫폼 서비스에서 UI 개발과 운영을 해왔습니다.
+            웹 표준, 접근성, 마크업 구조화, SCSS 설계, 반응형 UI 구현을 바탕으로
+            서비스 화면의 구조와 유지보수성을 개선해왔습니다.
+          </p>
+          <p>
+            현재는 모바일웹 상품상세처럼 여러 도메인이 맞물리는 화면을 운영하며,
+            HTML/SCSS 기반 산출물을 React 환경으로 옮기고 CSS 의존성을 프로젝트 안으로 정리하고 있습니다.
+            Storybook과 문서화, 리뷰 기준으로 컴포넌트 단위 검증 흐름도 만들고 있습니다.
+          </p>
+          <p>
+            AI는 반복 리뷰, 문서 초안, QA 체크리스트처럼 사람이 검토할 초안을 만드는 보조 흐름으로 다룹니다.
+            새 도구 자체보다 화면을 더 안전하게 바꾸고 검증하는 결과를 중요하게 봅니다.
+          </p>
+        </div>
+      </section>
+
+      <section className="pf-metrics" aria-label="주요 경험 수치">
+        <div><span className="pf-metric-path">migration.scss</span><strong>2,384</strong><span>SCSS 파일 전환</span></div>
+        <div><span className="pf-metric-path">documentation/</span><strong>70+</strong><span>기술 문서 작성</span></div>
+        <div><span className="pf-metric-path">review-pipeline/</span><strong>8</strong><span>저장소 리뷰 흐름 적용</span></div>
+        <div><span className="pf-metric-path">leadership.log</span><strong>3년</strong><span>실무 팀 리딩</span></div>
       </section>
 
       <hr className="pf-divider" />
 
       {/* 서비스 UI 운영 근거 */}
-      <section className="pf-section">
-        <h2 className="pf-section-title">서비스 UI 운영과 개선 근거</h2>
+      <section className="pf-section pf-section-dark" id="work">
+        <h2 className="pf-section-title"><span>$ cat work.md</span>서비스 UI 운영과 개선 근거</h2>
         <p className="pf-section-lead">
           포트폴리오에서 가장 먼저 보여주고 싶은 부분은 개인 서비스보다 오래 운영되는 화면을 안정적으로 바꿔온 경험입니다.
           화면 구현에만 머무르지 않고 영향 범위, 이해관계자, 검증 기준, 운영 피드백을 함께 보는 방식으로 일합니다.
@@ -78,8 +100,8 @@ export default function PortfolioPage() {
       <hr className="pf-divider" />
 
       {/* 공개 UI 구현 사례 */}
-      <section className="pf-section">
-        <h2 className="pf-section-title">공개 UI 구현 사례</h2>
+      <section className="pf-section pf-section-feature" id="case-study">
+        <h2 className="pf-section-title"><span>$ open case-study.tsx</span>공개 UI 구현 사례</h2>
         <p className="pf-section-lead">
           상품상세 UI를 운영하며 쌓은 경험을 바탕으로, 옵션 선택 흐름을 처음부터 새롭게 설계하고 구현했습니다.
           색상·사이즈 조합, 재고, 추가 금액, 모바일 화면 전환처럼 운영 중 자주 마주치는 상태를 하나의 공개 사례로 정리하고 확인 결과를 Storybook에 남겼습니다.
@@ -99,6 +121,10 @@ export default function PortfolioPage() {
           </p>
 
           <div className="pf-case-media">
+            <div className="pf-terminal-panel-bar">
+              <span>preview/commerce-options</span>
+              <span><i aria-hidden="true" /> running</span>
+            </div>
             <figure>
               <img className="pf-screenshot" src="/portfolio/ks-ui-product-options-desktop.jpg" alt="데스크톱 상품 옵션 선택 화면" />
               <figcaption className="pf-screenshot-caption">데스크톱 구매 패널</figcaption>
@@ -132,9 +158,36 @@ export default function PortfolioPage() {
 
       <hr className="pf-divider" />
 
+      {/* 포커스 */}
+      <section className="pf-section" id="approach">
+        <h2 className="pf-section-title"><span>$ cat approach.md</span>요즘 집중하는 것</h2>
+        <div className="pf-focus-grid">
+          <div className="pf-focus-card">
+            <h3>화면 구조와 영향 범위 보기</h3>
+            <p>
+              PDP처럼 여러 도메인이 맞물리는 화면에서 무엇이 바뀌고 어디까지 확인해야 하는지 먼저 나누는 데 집중합니다.
+            </p>
+          </div>
+          <div className="pf-focus-card">
+            <h3>컴포넌트 단위로 확인하기</h3>
+            <p>
+              Storybook과 문서화를 통해 기획, 디자인, 개발이 같은 화면 상태를 보고 이야기할 수 있게 정리합니다.
+            </p>
+          </div>
+          <div className="pf-focus-card">
+            <h3>반복 확인을 줄이는 흐름 만들기</h3>
+            <p>
+              리뷰 기준, 작업 정리, QA 체크리스트처럼 매번 반복되는 확인 항목을 검토 가능한 초안으로 만듭니다.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <hr className="pf-divider" />
+
       {/* 회사 안에서 적용한 AI 보조 흐름 */}
-      <section className="pf-section">
-        <h2 className="pf-section-title">반복 리뷰와 문서화를 줄인 AI 보조 흐름</h2>
+      <section className="pf-section pf-section-tinted" id="workflow">
+        <h2 className="pf-section-title"><span>$ tail systems.log</span>반복 리뷰와 문서화를 줄인 AI 보조 흐름</h2>
 
         <div className="pf-project">
           <div className="pf-project-header">
@@ -217,8 +270,8 @@ export default function PortfolioPage() {
       </section>
 
       {/* 개인 서비스 실험 */}
-      <section className="pf-section">
-        <h2 className="pf-section-title">작게 만든 제품 실험</h2>
+      <section className="pf-section" id="experiments">
+        <h2 className="pf-section-title"><span>$ ls experiments/</span>작게 만든 제품 실험</h2>
         <p className="pf-section-lead">
           업무에서는 주로 UI 운영과 개선을 맡아왔기 때문에, 개인 프로젝트에서는 API·DB·배치·배포까지 직접 다뤄보며 제품 개발 범위를 넓히고 있습니다.
           작은 가설을 서비스로 만들고, 운영하면서 어떤 반응을 보고 다음 수정을 할지 확인합니다.
@@ -314,8 +367,8 @@ export default function PortfolioPage() {
       <hr className="pf-divider" />
 
       {/* 에이전트 운영 환경 */}
-      <section className="pf-section">
-        <h2 className="pf-section-title">개인 에이전트 실험에서 확인한 운영 조건</h2>
+      <section className="pf-section pf-section-dark" id="agents">
+        <h2 className="pf-section-title"><span>$ inspect agents.json</span>개인 에이전트 실험에서 확인한 운영 조건</h2>
         <p className="pf-section-lead">
           이 섹션은 회사 적용 사례가 아니라, AI 워크플로우를 제품 환경에 붙일 때 필요한 조건을 확인한 개인 실험입니다.
           도구 이름보다 문서 출처, 접근 범위, 작업 로그, 사람 검토 지점을 어떻게 남길지가 핵심이라고 봅니다.
@@ -357,8 +410,8 @@ export default function PortfolioPage() {
       <hr className="pf-divider" />
 
       {/* PoC / 실험 */}
-      <section className="pf-section">
-        <h2 className="pf-section-title">빠른 검증을 반복합니다</h2>
+      <section className="pf-section pf-section-compact" id="prototypes">
+        <h2 className="pf-section-title"><span>$ cat prototypes.md</span>빠른 검증을 반복합니다</h2>
         <p className="pf-section-lead">
           위 서비스 외에도 아이디어가 생기면 1~2일 안에 MVP를 만들어 확인합니다.
           AI 구매 합리화, 국어사전 재가공, 유튜브 댓글 분석, 콘텐츠 제작 내부 도구처럼
@@ -369,8 +422,8 @@ export default function PortfolioPage() {
       <hr className="pf-divider" />
 
       {/* 블로그 */}
-      <section className="pf-section">
-        <h2 className="pf-section-title">관련 글</h2>
+      <section className="pf-section" id="writing">
+        <h2 className="pf-section-title"><span>$ find writing/</span>관련 글</h2>
 
         <div className="pf-blog-list">
           <a className="pf-blog-item" href="/tech/pdp-ui" target="_blank" rel="noopener noreferrer">
@@ -420,63 +473,71 @@ export default function PortfolioPage() {
 
       {/* FOOTER */}
       <div className="pf-footer">
-        <p style={{ fontSize: 20, fontWeight: 800, color: "var(--text)", marginBottom: 8 }}>김성재</p>
-        <p style={{ fontSize: 13, color: "var(--text3)", marginBottom: 12, lineHeight: 1.7 }}>
+        <p className="pf-footer-name">김성재</p>
+        <p className="pf-footer-copy">
           오래 운영되는 서비스 UI 경험을 바탕으로 화면 변경과 검증 흐름을 개선합니다.
         </p>
         <p>
           <a href="mailto:k.suzkim@gmail.com">k.suzkim@gmail.com</a>
         </p>
       </div>
-    </>
+      </main>
+
+      <div className="pf-statusbar" role="status" aria-label="포트폴리오 상태">
+        <span><i aria-hidden="true" /> ready</span>
+        <span>UI / Frontend Developer</span>
+        <span>UTF-8</span>
+        <span>320 · 390 · 1440</span>
+      </div>
+    </div>
   );
 }
 
 function ObsidianRagDiagram() {
   return (
-    <div style={{ margin: "20px 0" }}>
+    <div className="pf-diagram">
       <svg viewBox="0 0 700 210" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Obsidian RAG 검색 레이어 구조" style={{ width: "100%", height: "auto" }}>
         <defs>
           <marker id="ragArrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-            <path d="M0,0 L8,3 L0,6" fill="#7c6ff7" />
+            <path d="M0,0 L8,3 L0,6" fill="#2457d6" />
           </marker>
           <marker id="ragArrowGreen" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-            <path d="M0,0 L8,3 L0,6" fill="#34d399" />
+            <path d="M0,0 L8,3 L0,6" fill="#2457d6" />
           </marker>
         </defs>
 
-        <rect x="20" y="70" width="130" height="70" rx="8" fill="#1a1a24" stroke="#34d399" strokeWidth="1.5" />
-        <text x="85" y="98" textAnchor="middle" fill="#34d399" fontSize="12" fontWeight="700">Obsidian Vault</text>
-        <text x="85" y="116" textAnchor="middle" fill="#94a3b8" fontSize="9">문서 · 메모 · 작업 기록</text>
+        <rect x="20" y="70" width="130" height="70" rx="8" fill="#f4f6f7" stroke="#2457d6" strokeWidth="1.5" />
+        <text x="85" y="98" textAnchor="middle" fill="#2457d6" fontSize="12" fontWeight="700">Obsidian Vault</text>
+        <text x="85" y="116" textAnchor="middle" fill="#5b6367" fontSize="9">문서 · 메모 · 작업 기록</text>
 
-        <rect x="205" y="35" width="130" height="46" rx="8" fill="#1a1a24" stroke="#2a2a3a" />
-        <text x="270" y="57" textAnchor="middle" fill="#e2e8f0" fontSize="11" fontWeight="600">Watcher</text>
-        <text x="270" y="70" textAnchor="middle" fill="#94a3b8" fontSize="9">변경 감지</text>
+        <rect x="205" y="35" width="130" height="46" rx="8" fill="#f4f6f7" stroke="#d8dee1" />
+        <text x="270" y="57" textAnchor="middle" fill="#111413" fontSize="11" fontWeight="600">Watcher</text>
+        <text x="270" y="70" textAnchor="middle" fill="#5b6367" fontSize="9">변경 감지</text>
 
-        <rect x="205" y="112" width="130" height="46" rx="8" fill="#1a1a24" stroke="#2a2a3a" />
-        <text x="270" y="134" textAnchor="middle" fill="#e2e8f0" fontSize="11" fontWeight="600">Local Embedding</text>
-        <text x="270" y="147" textAnchor="middle" fill="#94a3b8" fontSize="9">Ollama</text>
+        <rect x="205" y="112" width="130" height="46" rx="8" fill="#f4f6f7" stroke="#d8dee1" />
+        <text x="270" y="134" textAnchor="middle" fill="#111413" fontSize="11" fontWeight="600">Local Embedding</text>
+        <text x="270" y="147" textAnchor="middle" fill="#5b6367" fontSize="9">Ollama</text>
 
-        <rect x="390" y="70" width="130" height="70" rx="8" fill="#1a1a24" stroke="#7c6ff7" strokeWidth="1.5" />
-        <text x="455" y="98" textAnchor="middle" fill="#a78bfa" fontSize="12" fontWeight="700">RAG Server</text>
-        <text x="455" y="116" textAnchor="middle" fill="#94a3b8" fontSize="9">FastAPI + ChromaDB</text>
+        <rect x="390" y="70" width="130" height="70" rx="8" fill="#f4f6f7" stroke="#2457d6" strokeWidth="1.5" />
+        <text x="455" y="98" textAnchor="middle" fill="#2457d6" fontSize="12" fontWeight="700">RAG Server</text>
+        <text x="455" y="116" textAnchor="middle" fill="#5b6367" fontSize="9">FastAPI + ChromaDB</text>
 
-        <rect x="570" y="25" width="105" height="36" rx="8" fill="#1a1a24" stroke="#2a2a3a" />
-        <text x="622" y="47" textAnchor="middle" fill="#e2e8f0" fontSize="10">Claude Code</text>
-        <rect x="570" y="86" width="105" height="36" rx="8" fill="#1a1a24" stroke="#2a2a3a" />
-        <text x="622" y="108" textAnchor="middle" fill="#e2e8f0" fontSize="10">Hermes</text>
-        <rect x="570" y="147" width="105" height="36" rx="8" fill="#1a1a24" stroke="#2a2a3a" />
-        <text x="622" y="169" textAnchor="middle" fill="#e2e8f0" fontSize="10">Codex / CLI</text>
+        <rect x="570" y="25" width="105" height="36" rx="8" fill="#f4f6f7" stroke="#d8dee1" />
+        <text x="622" y="47" textAnchor="middle" fill="#111413" fontSize="10">Claude Code</text>
+        <rect x="570" y="86" width="105" height="36" rx="8" fill="#f4f6f7" stroke="#d8dee1" />
+        <text x="622" y="108" textAnchor="middle" fill="#111413" fontSize="10">Hermes</text>
+        <rect x="570" y="147" width="105" height="36" rx="8" fill="#f4f6f7" stroke="#d8dee1" />
+        <text x="622" y="169" textAnchor="middle" fill="#111413" fontSize="10">Codex / CLI</text>
 
-        <line x1="150" y1="92" x2="203" y2="60" stroke="#34d399" strokeWidth="1.4" markerEnd="url(#ragArrowGreen)" />
-        <line x1="150" y1="118" x2="203" y2="135" stroke="#34d399" strokeWidth="1.4" markerEnd="url(#ragArrowGreen)" />
-        <line x1="335" y1="58" x2="388" y2="92" stroke="#7c6ff7" strokeWidth="1.4" markerEnd="url(#ragArrow)" />
-        <line x1="335" y1="135" x2="388" y2="118" stroke="#7c6ff7" strokeWidth="1.4" markerEnd="url(#ragArrow)" />
-        <line x1="520" y1="92" x2="568" y2="43" stroke="#7c6ff7" strokeWidth="1.2" markerEnd="url(#ragArrow)" />
-        <line x1="520" y1="105" x2="568" y2="105" stroke="#7c6ff7" strokeWidth="1.2" markerEnd="url(#ragArrow)" />
-        <line x1="520" y1="118" x2="568" y2="165" stroke="#7c6ff7" strokeWidth="1.2" markerEnd="url(#ragArrow)" />
+        <line x1="150" y1="92" x2="203" y2="60" stroke="#2457d6" strokeWidth="1.4" markerEnd="url(#ragArrowGreen)" />
+        <line x1="150" y1="118" x2="203" y2="135" stroke="#2457d6" strokeWidth="1.4" markerEnd="url(#ragArrowGreen)" />
+        <line x1="335" y1="58" x2="388" y2="92" stroke="#2457d6" strokeWidth="1.4" markerEnd="url(#ragArrow)" />
+        <line x1="335" y1="135" x2="388" y2="118" stroke="#2457d6" strokeWidth="1.4" markerEnd="url(#ragArrow)" />
+        <line x1="520" y1="92" x2="568" y2="43" stroke="#2457d6" strokeWidth="1.2" markerEnd="url(#ragArrow)" />
+        <line x1="520" y1="105" x2="568" y2="105" stroke="#2457d6" strokeWidth="1.2" markerEnd="url(#ragArrow)" />
+        <line x1="520" y1="118" x2="568" y2="165" stroke="#2457d6" strokeWidth="1.2" markerEnd="url(#ragArrow)" />
 
-        <text x="350" y="196" textAnchor="middle" fill="#64748b" fontSize="9">
+        <text x="350" y="196" textAnchor="middle" fill="#5b6367" fontSize="9">
           한 번 인덱싱한 Obsidian 문맥을 여러 에이전트가 같은 방식으로 검색
         </text>
       </svg>

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -8,11 +8,11 @@ export default function PortfolioPage() {
           <span aria-hidden="true">&gt;_</span> k.sungjae@portfolio:~$
         </a>
         <nav className="pf-cli-nav" aria-label="포트폴리오 탐색">
-          <a href="#top">About</a>
-          <a href="#work">Experience</a>
+          <a href="#work">Work</a>
           <a href="#case-study">Case Study</a>
-          <a href="#experiments">Experiments</a>
+          <a href="#services">Services</a>
           <a href="#writing">Writing</a>
+          <a href="/career">Career</a>
           <a href="mailto:k.suzkim@gmail.com">Contact</a>
         </nav>
         <p className="pf-cli-status"><i aria-hidden="true" /> UI / Frontend</p>
@@ -29,16 +29,9 @@ export default function PortfolioPage() {
         <p className="pf-hero-command"><span aria-hidden="true">$</span> whoami</p>
         <h1>김성재</h1>
         <p className="pf-hero-statement">
-          서비스 UI를 오래<br className="pf-break-mobile" />{" "}
-          운영하고,<br className="pf-break-desktop" />{" "}
-          더<br className="pf-break-mobile" />{" "}
-          안전하게 바꿉니다.
+          서비스 UI를 만들고 운영하며,<br className="pf-break-desktop" />{" "}
+          복잡한 구조를 꾸준히 개선해왔습니다.
         </p>
-        <div className="pf-hero-status" aria-label="핵심 역할과 경험">
-          <p><span>role</span><strong>UI / Frontend Developer</strong></p>
-          <p><span>scope</span><strong>모바일웹 PDP 운영</strong></p>
-          <p><span>migration</span><strong>2,384 SCSS · React 환경 이관</strong></p>
-        </div>
         <a className="pf-scroll-link" href="#work"><span aria-hidden="true">$</span> open ./work <span aria-hidden="true">↓</span></a>
       </header>
 
@@ -59,27 +52,20 @@ export default function PortfolioPage() {
             Storybook과 문서화, 리뷰 기준으로 컴포넌트 단위 검증 흐름도 만들고 있습니다.
           </p>
           <p>
-            AI는 반복 리뷰, 문서 초안, QA 체크리스트처럼 사람이 검토할 초안을 만드는 보조 흐름으로 다룹니다.
-            새 도구 자체보다 화면을 더 안전하게 바꾸고 검증하는 결과를 중요하게 봅니다.
+            반복되는 리뷰 항목과 PR 설명, 문서 초안, QA 체크리스트는 AI로 먼저 정리한 뒤 검토해 활용합니다.
+            이를 팀에서 재사용할 수 있도록 규칙과 작업 흐름도 함께 정리하고 있습니다.
           </p>
         </div>
       </section>
 
-      <section className="pf-metrics" aria-label="주요 경험 수치">
-        <div><span className="pf-metric-path">migration.scss</span><strong>2,384</strong><span>SCSS 파일 전환</span></div>
-        <div><span className="pf-metric-path">documentation/</span><strong>70+</strong><span>기술 문서 작성</span></div>
-        <div><span className="pf-metric-path">review-pipeline/</span><strong>8</strong><span>저장소 리뷰 흐름 적용</span></div>
-        <div><span className="pf-metric-path">leadership.log</span><strong>3년</strong><span>실무 팀 리딩</span></div>
-      </section>
-
       <hr className="pf-divider" />
 
-      {/* 서비스 UI 운영 근거 */}
+      {/* 서비스 UI 운영과 개선 */}
       <section className="pf-section pf-section-dark" id="work">
-        <h2 className="pf-section-title"><span>$ cat work.md</span>서비스 UI 운영과 개선 근거</h2>
+        <h2 className="pf-section-title"><span>$ cat work.md</span>서비스 UI 운영과 개선</h2>
         <p className="pf-section-lead">
-          포트폴리오에서 가장 먼저 보여주고 싶은 부분은 개인 서비스보다 오래 운영되는 화면을 안정적으로 바꿔온 경험입니다.
-          화면 구현에만 머무르지 않고 영향 범위, 이해관계자, 검증 기준, 운영 피드백을 함께 보는 방식으로 일합니다.
+          운영 중인 화면을 바꿀 때는 구현뿐 아니라 영향 범위, 협업 대상, 검증 기준과 반영 이후의 결과까지 함께 확인합니다.
+          여러 도메인이 맞물리는 화면을 맡으며 변경 단위를 나누고 안정적으로 반영하는 경험을 쌓았습니다.
         </p>
         <div className="pf-poc-grid">
           <div className="pf-poc-card">
@@ -87,24 +73,24 @@ export default function PortfolioPage() {
             <p>가격, 옵션, 리뷰, 배송, 프로모션처럼 여러 도메인이 맞물리는 상품상세 UI를 맡으며 기획·디자인·백엔드와 영향 범위를 확인했습니다.</p>
           </div>
           <div className="pf-poc-card">
-            <h4>오래된 스타일 구조 개선</h4>
-            <p>2,384개 SCSS 파일 규모의 Dart Sass 전환, CSS 내재화, React 환경 이관을 진행하며 변경 단위와 산출물 차이를 나눠 검증했습니다.</p>
+            <h4>SCSS 구조와 CSS 의존성 개선</h4>
+            <p>2,384개 SCSS 파일을 Dart Sass로 전환하며 CSS 산출물 차이를 확인했습니다. 이후 분산된 CSS를 React 프로젝트 안으로 옮겨 화면 코드와 스타일 변경 맥락을 함께 관리하도록 정리했습니다.</p>
           </div>
           <div className="pf-poc-card">
             <h4>컴포넌트 검증과 문서화</h4>
-            <p>Storybook 기반 확인 환경과 70여 건의 기술 문서로 신규 작업자 온보딩, 오래된 화면 수정, 컴포넌트 단위 커뮤니케이션을 정리했습니다.</p>
+            <p>Storybook 기반 확인 환경과 기술 문서로 신규 작업자 온보딩, 기존 화면 수정, 컴포넌트 단위 커뮤니케이션에 필요한 기준을 정리했습니다.</p>
           </div>
         </div>
       </section>
 
       <hr className="pf-divider" />
 
-      {/* 공개 UI 구현 사례 */}
+      {/* 실무 경험을 바탕으로 만든 UI */}
       <section className="pf-section pf-section-feature" id="case-study">
-        <h2 className="pf-section-title"><span>$ open case-study.tsx</span>공개 UI 구현 사례</h2>
+        <h2 className="pf-section-title"><span>$ open ui-case.tsx</span>업무 경험을 바탕으로 새로 만든 UI</h2>
         <p className="pf-section-lead">
-          상품상세 UI를 운영하며 쌓은 경험을 바탕으로, 옵션 선택 흐름을 처음부터 새롭게 설계하고 구현했습니다.
-          색상·사이즈 조합, 재고, 추가 금액, 모바일 화면 전환처럼 운영 중 자주 마주치는 상태를 하나의 공개 사례로 정리하고 확인 결과를 Storybook에 남겼습니다.
+          상품상세 UI를 운영하며 자주 마주친 상태와 예외 케이스를 바탕으로 옵션 선택 흐름을 새로 설계했습니다.
+          색상·사이즈 조합, 재고, 추가 금액, 모바일 화면 전환을 공개 컴포넌트로 구현하고 확인 결과를 Storybook에 남겼습니다.
         </p>
 
         <div className="pf-project">
@@ -158,47 +144,19 @@ export default function PortfolioPage() {
 
       <hr className="pf-divider" />
 
-      {/* 포커스 */}
-      <section className="pf-section" id="approach">
-        <h2 className="pf-section-title"><span>$ cat approach.md</span>요즘 집중하는 것</h2>
-        <div className="pf-focus-grid">
-          <div className="pf-focus-card">
-            <h3>화면 구조와 영향 범위 보기</h3>
-            <p>
-              PDP처럼 여러 도메인이 맞물리는 화면에서 무엇이 바뀌고 어디까지 확인해야 하는지 먼저 나누는 데 집중합니다.
-            </p>
-          </div>
-          <div className="pf-focus-card">
-            <h3>컴포넌트 단위로 확인하기</h3>
-            <p>
-              Storybook과 문서화를 통해 기획, 디자인, 개발이 같은 화면 상태를 보고 이야기할 수 있게 정리합니다.
-            </p>
-          </div>
-          <div className="pf-focus-card">
-            <h3>반복 확인을 줄이는 흐름 만들기</h3>
-            <p>
-              리뷰 기준, 작업 정리, QA 체크리스트처럼 매번 반복되는 확인 항목을 검토 가능한 초안으로 만듭니다.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      <hr className="pf-divider" />
-
       {/* 회사 안에서 적용한 AI 보조 흐름 */}
       <section className="pf-section pf-section-tinted" id="workflow">
-        <h2 className="pf-section-title"><span>$ tail systems.log</span>반복 리뷰와 문서화를 줄인 AI 보조 흐름</h2>
+        <h2 className="pf-section-title"><span>$ tail ai-workflow.log</span>개발 업무에 적용한 AI 도구와 규칙</h2>
 
         <div className="pf-project">
           <div className="pf-project-header">
-            <h3>팀 개발 흐름에 맞춘 AI 보조 환경 정리</h3>
+            <h3>팀에서 함께 쓰는 규칙과 작성 흐름</h3>
             <span className="pf-badge pf-badge-running">실무 적용</span>
           </div>
           <p className="pf-project-desc">
-            팀에서 AI 코딩 도구를 쓰기 시작하면 개인마다 프롬프트와 규칙이 흩어지기 쉽습니다.
-            저는 이 문제를 개인 생산성 문제가 아니라 팀 운영 문제로 보고, Cursor 규칙과 스킬을 팀 기준으로 정리했습니다.
-            PR 설명, 커밋 메시지, 작업 계획, 위키 작성, QA 체크리스트처럼 매번 새로 쓰던 산출물을 먼저 대상으로 잡고,
-            저장소별로 같은 기준을 재사용할 수 있는 흐름을 만들었습니다.
+            Cursor 규칙과 스킬을 팀의 UI 개발 기준에 맞춰 정리했습니다.
+            PR 설명, 커밋 메시지, 작업 계획, 위키 초안, QA 체크리스트처럼 자주 작성하는 산출물에 공통 형식을 적용했고,
+            여러 저장소에서 같은 설정을 재사용할 수 있도록 관리와 동기화 흐름을 구성했습니다.
           </p>
           <div className="pf-detail">
             <h4>한 일</h4>
@@ -213,10 +171,10 @@ export default function PortfolioPage() {
           <div className="pf-detail">
             <h4>바뀐 점</h4>
             <ul>
-              <li>AI 사용을 개인별 요령이 아니라 팀에서 재사용 가능한 규칙과 산출물 형식으로 고정</li>
-              <li>PR, 커밋, 위키, QA처럼 매번 새로 쓰던 내용을 검토 가능한 초안으로 먼저 만들도록 정리</li>
-              <li>사람은 초안 작성보다 맥락 확인, 영향 범위 판단, 예외 케이스 검토에 시간을 쓰도록 역할을 분리</li>
-              <li>AI가 참고할 문맥, 사람이 확인할 지점, 공개 문서에 남기지 말아야 할 정보를 함께 정리</li>
+              <li>개인마다 달랐던 프롬프트와 작성 형식을 팀 공통 규칙으로 정리</li>
+              <li>PR, 커밋, 위키, QA 산출물을 일정한 형식의 초안으로 생성</li>
+              <li>리뷰 단계에서 맥락, 영향 범위, 예외 케이스 확인에 집중할 수 있도록 반복 작성 작업 축소</li>
+              <li>참고할 문맥의 범위와 공개 문서에 남기지 말아야 할 정보를 사용 기준에 포함</li>
             </ul>
           </div>
           <div className="pf-chips">
@@ -236,8 +194,8 @@ export default function PortfolioPage() {
           </div>
           <p className="pf-project-desc">
             UI 개발 리뷰에서는 BEM 네이밍, SCSS 구조, 접근성 속성, 중복 스타일처럼 반복해서 보는 항목이 많습니다.
-            이 부분을 사람이 매번 처음부터 확인하지 않도록, 여러 저장소의 파이프라인에 PR diff 기반 AI 리뷰 스텝을 붙였습니다.
-            목표는 사람 리뷰를 없애는 것이 아니라, 반복 컨벤션 체크와 사람이 판단해야 하는 설계·영향 범위 검토를 분리하는 것이었습니다.
+            여러 저장소의 파이프라인에 PR diff 기반 AI 리뷰 스텝을 붙여 이 항목들을 먼저 확인하도록 구성했습니다.
+            설계, 영향 범위, 예외 케이스는 기존 코드 리뷰에서 별도로 확인했습니다.
           </p>
           <div className="pf-detail">
             <h4>한 일</h4>
@@ -246,16 +204,16 @@ export default function PortfolioPage() {
               <li>SCSS, HTML 마크업 중심으로 파일 필터링 규칙 설정</li>
               <li>팀의 접근성, BEM, SCSS 컨벤션을 리뷰 기준에 반영</li>
               <li>자동 트리거와 수동 트리거 방식을 나눠 실제 업무 흐름에 맞게 조정</li>
-              <li>AI 코멘트를 그대로 믿지 않고, 사람이 확인해야 할 항목과 단순 반복 체크를 분리</li>
+              <li>반복 컨벤션과 설계·영향 범위 검토 항목을 분리</li>
             </ul>
           </div>
           <div className="pf-detail">
             <h4>운영 기준</h4>
             <ul>
-              <li>반복 컨벤션 체크는 AI가 먼저 확인하고, 사람 리뷰는 구조·영향 범위·예외 판단에 집중하도록 분리</li>
+              <li>접근성, BEM, SCSS 규칙처럼 명확한 항목부터 확인</li>
               <li>리뷰 기준을 개인 기억에 의존하지 않고 접근성, BEM, SCSS 규칙으로 명문화</li>
-              <li>AI 리뷰 결과를 머지 판단이 아니라 사람이 확인할 체크리스트 초안으로 다루는 방식으로 운영</li>
-              <li>과한 코멘트와 오탐은 리뷰 기준을 조정하는 입력으로 보고, 자동 차단보다 사람 검토를 우선</li>
+              <li>리뷰 결과는 머지 조건이 아닌 확인 항목으로 제공</li>
+              <li>과한 코멘트와 오탐은 규칙을 조정하는 기준으로 기록</li>
             </ul>
           </div>
           <div className="pf-chips">
@@ -269,12 +227,12 @@ export default function PortfolioPage() {
 
       </section>
 
-      {/* 개인 서비스 실험 */}
-      <section className="pf-section" id="experiments">
-        <h2 className="pf-section-title"><span>$ ls experiments/</span>작게 만든 제품 실험</h2>
+      {/* 개인 서비스와 자동화 */}
+      <section className="pf-section" id="services">
+        <h2 className="pf-section-title"><span>$ ls side-projects/</span>직접 만든 서비스와 자동화</h2>
         <p className="pf-section-lead">
-          업무에서는 주로 UI 운영과 개선을 맡아왔기 때문에, 개인 프로젝트에서는 API·DB·배치·배포까지 직접 다뤄보며 제품 개발 범위를 넓히고 있습니다.
-          작은 가설을 서비스로 만들고, 운영하면서 어떤 반응을 보고 다음 수정을 할지 확인합니다.
+          개인 프로젝트에서는 화면 구현부터 API, DB, 배치 작업과 배포까지 직접 다룹니다.
+          서비스와 자동화를 직접 운영하면서 사용 흐름을 확인하고 필요한 기능을 보완하고 있습니다.
         </p>
 
         <div className="pf-service-grid">
@@ -288,8 +246,8 @@ export default function PortfolioPage() {
                 <span className="pf-badge pf-badge-live">운영 중</span>
               </div>
               <p>
-                검색 유입형 육아용품 가이드가 쌓이면 커머스 진입점을 만들 수 있다는 가설로 시작했습니다.
-                Search Console 키워드, GAS, Gemini, API 웹훅을 연결해 매일 4건씩 자동 발행하고, 누적 183건 이상의 콘텐츠 반응을 보며 방향을 조정합니다.
+                육아용품 가이드와 상품 정보를 함께 제공하는 커머스 서비스입니다.
+                Search Console 키워드, GAS, Gemini, API 웹훅을 연결해 매일 콘텐츠를 발행하고 있습니다.
               </p>
               <div className="pf-chips">
                 <span className="pf-chip">Next.js</span>
@@ -309,34 +267,14 @@ export default function PortfolioPage() {
                 <span className="pf-badge pf-badge-live">운영 중</span>
               </div>
               <p>
-                쇼츠 영상에서 상품 랜딩으로 이어지는 전환 흐름을 직접 검증하기 위해 만들었습니다.
-                랜딩, 상품 등록·수정 어드민, 통계 확인 화면을 묶어 영상 반응에 따라 노출 상품과 구성을 바꿔봅니다.
+                쇼츠 영상에서 소개한 상품을 한곳에서 확인할 수 있도록 만든 서비스입니다.
+                랜딩 페이지와 상품 등록·수정 어드민, 통계 화면을 함께 운영하며 노출 상품과 화면 구성을 조정하고 있습니다.
               </p>
               <div className="pf-chips">
                 <span className="pf-chip">Next.js 16</span>
                 <span className="pf-chip">React 19</span>
                 <span className="pf-chip">Tailwind v4</span>
                 <span className="pf-chip">Supabase</span>
-              </div>
-            </div>
-          </div>
-
-          <div className="pf-service-card">
-            <img src="/portfolio/shorts-planner-1.png" alt="쇼츠 플래너 — 영상 분석과 훅 생성 화면" />
-            <div>
-              <div className="pf-project-header">
-                <h3>쇼츠 플래너</h3>
-                <span className="pf-badge pf-badge-running">운영 중</span>
-              </div>
-              <p>
-                콘텐츠 제작에서 반복되는 준비 시간을 줄이기 위해 만든 내부 도구입니다.
-                레퍼런스 분석, 대본, TTS, 썸네일, 제목·해시태그 초안을 만들고 사람은 최종 편집과 업로드 판단에 집중합니다.
-              </p>
-              <div className="pf-chips">
-                <span className="pf-chip">Next.js</span>
-                <span className="pf-chip">Gemini API</span>
-                <span className="pf-chip">TTS</span>
-                <span className="pf-chip">Vercel</span>
               </div>
             </div>
           </div>
@@ -351,7 +289,7 @@ export default function PortfolioPage() {
               </div>
               <p>
                 매일 뉴스를 읽고 글로 남기는 과정이 끊기지 않도록 만든 자동화입니다.
-                GeekNews 수집, 텔레그램 후보 발송, 기사 선택, AI 분석, 블로그 MDX 초안, GitHub PR 생성을 묶고 사람은 선별과 최종 리뷰를 맡습니다.
+                GeekNews 수집, 텔레그램 후보 발송, 기사 선택, AI 분석, 블로그 MDX 초안과 GitHub PR 생성을 하나의 흐름으로 연결했습니다.
               </p>
               <div className="pf-chips">
                 <span className="pf-chip">Node.js</span>
@@ -368,31 +306,31 @@ export default function PortfolioPage() {
 
       {/* 에이전트 운영 환경 */}
       <section className="pf-section pf-section-dark" id="agents">
-        <h2 className="pf-section-title"><span>$ inspect agents.json</span>개인 에이전트 실험에서 확인한 운영 조건</h2>
+        <h2 className="pf-section-title"><span>$ cat agent-workspace.md</span>AI 에이전트 작업 환경</h2>
         <p className="pf-section-lead">
-          이 섹션은 회사 적용 사례가 아니라, AI 워크플로우를 제품 환경에 붙일 때 필요한 조건을 확인한 개인 실험입니다.
-          도구 이름보다 문서 출처, 접근 범위, 작업 로그, 사람 검토 지점을 어떻게 남길지가 핵심이라고 봅니다.
+          OpenClaw, Hermes, Obsidian RAG를 조합해 개인 작업 환경을 구성했습니다.
+          문서 출처와 접근 범위, 작업 로그를 남겨 결과와 실행 과정을 다시 확인할 수 있게 했습니다.
         </p>
 
         <div className="pf-project">
           <div className="pf-project-header">
-            <h3>문서·도구·로그가 분리된 작업 환경</h3>
+            <h3>Hermes와 Obsidian RAG를 연결한 작업 환경</h3>
             <a className="pf-project-link" href="/tech/ai-workspace" target="_blank" rel="noopener noreferrer">초기 구조 ↗</a>
             <a className="pf-project-link" href="/tech/hermes-agent-runtime" target="_blank" rel="noopener noreferrer">전환 과정 ↗</a>
             <a className="pf-project-link" href="/tech/obsidian-rag" target="_blank" rel="noopener noreferrer">RAG 글 ↗</a>
           </div>
           <p className="pf-project-desc">
             OpenClaw로 시작한 개인 에이전트 환경을 Hermes 중심으로 정리하고, Obsidian 문서를 로컬 RAG로 인덱싱했습니다.
-            에이전트가 답을 만들기 전에 어떤 문서를 참고했는지 사람이 다시 확인할 수 있게 하는 데 초점을 뒀습니다.
+            답변에 사용된 문서와 작업 과정을 함께 남겨 이후에도 출처와 실행 내용을 확인할 수 있게 했습니다.
           </p>
           <div className="pf-detail">
-            <h4>확인한 운영 조건</h4>
+            <h4>운영하며 정한 기준</h4>
             <ul>
-              <li><strong>문서 출처</strong> — 답변에 사용한 원본 문서를 함께 반환해 사람이 근거를 확인할 수 있게 설계</li>
-              <li><strong>접근 범위</strong> — 에이전트가 읽을 수 있는 파일과 실행할 수 있는 도구를 분리해서 생각해야 함</li>
-              <li><strong>작업 로그</strong> — 결과만 남기지 않고 판단 근거, 실패 지점, 다음 액션을 함께 기록해야 재사용 가능함</li>
-              <li><strong>사람 검토</strong> — AI 결과는 최종 판단이 아니라 코드, 문서, 체크리스트 초안으로 남겨야 함</li>
-              <li><strong>로컬 검색</strong> — 민감한 문맥을 다룰 때는 외부 전송 범위와 로컬 처리 범위를 먼저 나눠야 함</li>
+              <li><strong>문서 출처</strong> — 답변에 사용한 원본 문서를 함께 반환하도록 설계</li>
+              <li><strong>접근 범위</strong> — 읽을 수 있는 파일과 실행할 수 있는 도구를 각각 제한</li>
+              <li><strong>작업 로그</strong> — 판단 근거, 실패 지점, 다음 액션을 함께 기록</li>
+              <li><strong>결과 확인</strong> — 코드, 문서, 체크리스트 초안을 실행 전후에 확인할 수 있도록 기록</li>
+              <li><strong>로컬 검색</strong> — 외부 전송 범위와 로컬 처리 범위를 구분</li>
             </ul>
           </div>
           <ObsidianRagDiagram />
@@ -409,21 +347,9 @@ export default function PortfolioPage() {
 
       <hr className="pf-divider" />
 
-      {/* PoC / 실험 */}
-      <section className="pf-section pf-section-compact" id="prototypes">
-        <h2 className="pf-section-title"><span>$ cat prototypes.md</span>빠른 검증을 반복합니다</h2>
-        <p className="pf-section-lead">
-          위 서비스 외에도 아이디어가 생기면 1~2일 안에 MVP를 만들어 확인합니다.
-          AI 구매 합리화, 국어사전 재가공, 유튜브 댓글 분석, 콘텐츠 제작 내부 도구처럼
-          반응이 있는 것은 고도화하고, 없는 것은 빠르게 접어 다음 가설을 테스트합니다.
-        </p>
-      </section>
-
-      <hr className="pf-divider" />
-
       {/* 블로그 */}
       <section className="pf-section" id="writing">
-        <h2 className="pf-section-title"><span>$ find writing/</span>관련 글</h2>
+        <h2 className="pf-section-title"><span>$ find writing/</span>기술 기록</h2>
 
         <div className="pf-blog-list">
           <a className="pf-blog-item" href="/tech/pdp-ui" target="_blank" rel="noopener noreferrer">
@@ -446,26 +372,6 @@ export default function PortfolioPage() {
             <div className="pf-blog-title">AI 기반 개발 환경 구축 ↗</div>
             <div className="pf-blog-desc">팀에서 쓰는 AI 규칙, 스킬, MCP 연동, PR 리뷰 흐름을 정리한 기록</div>
           </a>
-          <a className="pf-blog-item" href="/tech/ai-workspace" target="_blank" rel="noopener noreferrer">
-            <div className="pf-blog-title">개인 AI 에이전트 워크스페이스 설계 ↗</div>
-            <div className="pf-blog-desc">OpenClaw, Ollama Cloud, Discord, Obsidian을 묶으며 확인한 에이전트 운영 조건</div>
-          </a>
-          <a className="pf-blog-item" href="/tech/hermes-agent-runtime" target="_blank" rel="noopener noreferrer">
-            <div className="pf-blog-title">OpenClaw에서 Hermes로 갈아탄 이유 ↗</div>
-            <div className="pf-blog-desc">지시 채널, MCP, RAG, 작업 로그, 사람 검토 단계를 분리해 다시 정리한 과정</div>
-          </a>
-          <a className="pf-blog-item" href="/tech/obsidian-rag" target="_blank" rel="noopener noreferrer">
-            <div className="pf-blog-title">Obsidian RAG — 에이전트가 내 문서를 찾아보게 하기 ↗</div>
-            <div className="pf-blog-desc">Obsidian 문서를 로컬 임베딩·ChromaDB·MCP로 연결해 여러 에이전트가 같은 맥락을 검색하는 구조</div>
-          </a>
-          <a className="pf-blog-item" href="/tech/pr-review-agent" target="_blank" rel="noopener noreferrer">
-            <div className="pf-blog-title">AI PR Review Agent 적용 및 운영 ↗</div>
-            <div className="pf-blog-desc">반복 리뷰를 AI가 먼저 확인하고 사람이 판단하는 흐름으로 바꾼 작업</div>
-          </a>
-          <a className="pf-blog-item" href="/tech/ai-news-agent" target="_blank" rel="noopener noreferrer">
-            <div className="pf-blog-title">텔레그램 봇으로 만드는 개인 뉴스 에이전트 ↗</div>
-            <div className="pf-blog-desc">GeekNews 크롤링 → AI 분석 → 블로그 PR 자동 생성까지</div>
-          </a>
         </div>
       </section>
 
@@ -475,11 +381,12 @@ export default function PortfolioPage() {
       <div className="pf-footer">
         <p className="pf-footer-name">김성재</p>
         <p className="pf-footer-copy">
-          오래 운영되는 서비스 UI 경험을 바탕으로 화면 변경과 검증 흐름을 개선합니다.
+          서비스 UI를 운영하며 쌓은 경험으로 화면 변경과 검증 흐름을 개선합니다.
         </p>
-        <p>
-          <a href="mailto:k.suzkim@gmail.com">k.suzkim@gmail.com</a>
-        </p>
+        <nav className="pf-footer-actions" aria-label="포트폴리오 다음 이동">
+          <a href="/career">전체 경력 보기 →</a>
+          <a href="mailto:k.suzkim@gmail.com">이메일 보내기 →</a>
+        </nav>
       </div>
       </main>
 

--- a/src/app/portfolio/portfolio.css
+++ b/src/app/portfolio/portfolio.css
@@ -813,6 +813,15 @@ body:has(.portfolio-root) > main {
   line-height: 1.8;
 }
 
+.pf-footer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 13px;
+  font-weight: 700;
+}
+
 .pf-footer a:hover,
 .pf-footer a:focus-visible {
   text-decoration: underline;
@@ -2196,7 +2205,6 @@ body:has(.portfolio-root) {
 }
 
 .pf-section-title {
-  grid-template-columns: 150px minmax(0, 1fr);
   margin-bottom: 46px;
   font-size: 32px;
 }
@@ -2204,10 +2212,6 @@ body:has(.portfolio-root) {
 .pf-section-title > span {
   padding-top: 7px;
   font-size: 10px;
-}
-
-.pf-section-lead {
-  margin-left: 174px;
 }
 
 .pf-footer {

--- a/src/app/portfolio/portfolio.css
+++ b/src/app/portfolio/portfolio.css
@@ -1,11 +1,11 @@
-/* Hide blog Header/Footer when portfolio is active */
+/* Portfolio owns its own frame. */
 body:has(.portfolio-root) > header,
 body:has(.portfolio-root) > footer {
   display: none !important;
 }
 
 body:has(.portfolio-root) {
-  background: #0a0a0f !important;
+  background: #ffffff !important;
 }
 
 body:has(.portfolio-root) > main {
@@ -13,289 +13,648 @@ body:has(.portfolio-root) > main {
 }
 
 .portfolio-root {
-  --bg: #0a0a0f;
-  --bg2: #111118;
-  --bg3: #1a1a24;
-  --border: #2a2a3a;
-  --accent: #7c6ff7;
-  --accent2: #a78bfa;
-  --green: #34d399;
-  --blue: #60a5fa;
-  --orange: #fb923c;
-  --pink: #f472b6;
-  --text: #e2e8f0;
-  --text2: #94a3b8;
-  --text3: #64748b;
+  --paper: #ffffff;
+  --surface: #ffffff;
+  --soft: #f4f6f7;
+  --ink: #111413;
+  --muted: #5b6367;
+  --line: #d8dee1;
+  --blue: #2457d6;
+  --terminal: #111413;
+  --terminal-line: #343938;
+  --terminal-muted: #9da5a2;
+  --blue-on-dark: #86a5ff;
 
-  background: var(--bg);
-  color: var(--text);
-  line-height: 1.7;
   min-height: 100vh;
+  overflow: clip;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-geist-sans), var(--font-noto-sans-kr), system-ui, sans-serif;
+  line-height: 1.7;
 }
 
-/* ── HERO ── */
+.portfolio-root *,
+.portfolio-root *::before,
+.portfolio-root *::after {
+  letter-spacing: 0;
+}
+
+.portfolio-root ::selection {
+  background: var(--blue);
+  color: #ffffff;
+}
+
+/* Navigation */
+.pf-nav {
+  position: sticky;
+  z-index: 20;
+  top: 0;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  min-height: 64px;
+  padding: 0 max(48px, calc((100% - 1280px) / 2));
+  background: rgba(17, 20, 19, 0.96);
+  border-bottom: 1px solid var(--terminal-line);
+  backdrop-filter: blur(14px);
+}
+
+.pf-nav a {
+  color: #d9dddc;
+  text-decoration: none;
+}
+
+.pf-nav-brand {
+  justify-self: start;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.pf-nav-brand-short {
+  display: none;
+}
+
+.pf-nav-links {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  font-size: 13px;
+}
+
+.pf-nav-links a,
+.pf-nav-contact {
+  position: relative;
+}
+
+.pf-nav-links a::after,
+.pf-nav-contact::after {
+  position: absolute;
+  right: 0;
+  bottom: -5px;
+  left: 0;
+  height: 1px;
+  background: currentColor;
+  content: "";
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform 180ms ease;
+}
+
+.pf-nav-links a:hover::after,
+.pf-nav-links a:focus-visible::after,
+.pf-nav-contact:hover::after,
+.pf-nav-contact:focus-visible::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+.pf-nav-contact {
+  justify-self: end;
+  color: var(--blue-on-dark) !important;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+/* Hero */
 .pf-hero {
-  padding: 100px 24px 80px;
-  max-width: 800px;
-  margin: 0 auto;
+  display: grid;
+  min-height: 720px;
+  padding: 72px max(48px, calc((100% - 1280px) / 2)) 64px;
+  background: var(--terminal);
+  border-bottom: 1px solid var(--terminal-line);
+  color: #f5f7f6;
+}
+
+.pf-hero-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  align-self: start;
+  color: var(--terminal-muted);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 12px;
+}
+
+.pf-hero-meta span:last-child,
+.pf-terminal-panel-bar span:last-child {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pf-hero-meta i,
+.pf-terminal-panel-bar i {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  background: var(--blue-on-dark);
+  border-radius: 50%;
+}
+
+.pf-hero-command {
+  align-self: end;
+  margin: 64px 0 0;
+  color: #d9dddc;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 15px;
+}
+
+.pf-hero-command span {
+  margin-right: 10px;
+  color: var(--blue-on-dark);
 }
 
 .pf-hero h1 {
-  font-size: clamp(28px, 5vw, 44px);
-  font-weight: 800;
-  letter-spacing: -0.03em;
-  line-height: 1.3;
-  margin-bottom: 20px;
-  color: var(--text);
+  margin: 22px 0 0;
+  color: #f5f7f6;
+  font-size: 88px;
+  font-weight: 700;
+  line-height: 1;
 }
 
-.pf-hero-desc {
-  font-size: 16px;
-  color: var(--text2);
+.pf-hero-statement {
+  max-width: 980px;
+  margin: 24px 0 0;
+  color: #f5f7f6;
+  font-size: 48px;
+  font-weight: 500;
+  line-height: 1.24;
+}
+
+.pf-break-mobile {
+  display: none;
+}
+
+.pf-hero-status {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 48px;
+  border-top: 1px solid var(--terminal-line);
+  border-bottom: 1px solid var(--terminal-line);
+}
+
+.pf-hero-status p {
+  min-width: 0;
+  margin: 0;
+  padding: 18px 22px 20px 0;
+}
+
+.pf-hero-status p + p {
+  padding-left: 22px;
+  border-left: 1px solid var(--terminal-line);
+}
+
+.pf-hero-status span,
+.pf-hero-status strong {
+  display: block;
+}
+
+.pf-hero-status span {
+  margin-bottom: 7px;
+  color: var(--blue-on-dark);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 10px;
+}
+
+.pf-hero-status strong {
+  color: #f5f7f6;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.pf-hero-copy {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 32px;
+  margin-top: 32px;
+  padding-top: 0;
+  counter-reset: hero-copy;
+}
+
+.pf-hero-copy p {
+  position: relative;
+  margin: 0;
+  padding-left: 32px;
+  color: var(--terminal-muted);
+  font-size: 14px;
   line-height: 1.8;
-  max-width: 640px;
 }
 
-.pf-hero-desc strong { color: var(--text); font-weight: 600; }
+.pf-hero-copy p::before {
+  position: absolute;
+  top: 1px;
+  left: 0;
+  color: #626967;
+  content: "0" counter(hero-copy);
+  counter-increment: hero-copy;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 10px;
+}
 
-/* ── SECTION ── */
+.pf-scroll-link {
+  display: inline-flex;
+  align-items: center;
+  justify-self: start;
+  gap: 12px;
+  margin-top: 36px;
+  color: var(--blue-on-dark);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.pf-scroll-link span {
+  font-size: 17px;
+}
+
+/* Metrics */
+.pf-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border-top: 1px solid var(--terminal-line);
+  border-bottom: 1px solid var(--terminal-line);
+  background: var(--terminal);
+}
+
+.pf-metrics > div {
+  min-width: 0;
+  padding: 30px 32px;
+}
+
+.pf-metrics > div + div {
+  border-left: 1px solid var(--terminal-line);
+}
+
+.pf-metrics strong,
+.pf-metrics span {
+  display: block;
+}
+
+.pf-metrics strong {
+  color: #f5f7f6;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 36px;
+  line-height: 1;
+}
+
+.pf-metrics span {
+  margin-top: 10px;
+  color: #d9dddc;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.pf-metrics .pf-metric-path {
+  margin: 0 0 18px;
+  color: var(--blue-on-dark);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 10px;
+  font-weight: 500;
+}
+
+/* Sections */
 .pf-section {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 60px 24px;
+  padding: 104px max(48px, calc((100% - 1280px) / 2));
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+  scroll-margin-top: 64px;
+}
+
+.pf-section-tinted {
+  background: var(--surface);
+}
+
+.pf-section-dark {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.pf-section-feature {
+  border-top: 2px solid var(--blue);
+  background: #ffffff;
+}
+
+.pf-section-compact {
+  padding-top: 72px;
+  padding-bottom: 72px;
+  background: var(--surface);
 }
 
 .pf-section-title {
-  font-size: clamp(20px, 3.5vw, 28px);
-  font-weight: 800;
-  letter-spacing: -0.02em;
-  margin-bottom: 40px;
-  color: var(--text);
-  padding-bottom: 16px;
-  border-bottom: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: 160px minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+  margin: 0 0 56px;
+  color: var(--ink);
+  font-size: 36px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.pf-section-title > span {
+  padding-top: 8px;
+  color: var(--blue);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.pf-section-dark .pf-section-title > span {
+  color: var(--blue);
+}
+
+.pf-section-compact .pf-section-title > span {
+  color: var(--blue);
 }
 
 .pf-section-lead {
-  font-size: 14px;
-  color: var(--text3);
-  line-height: 1.7;
-  margin: -24px 0 28px;
-}
-
-/* ── DIVIDER ── */
-.pf-divider {
-  border: none;
-  border-top: 1px solid var(--border);
   max-width: 800px;
-  margin: 0 auto;
+  margin: -24px 0 48px 184px;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.85;
 }
 
-/* ── PROJECT CARD ── */
+.pf-divider {
+  display: none;
+}
+
+/* Approach */
+.pf-focus-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+}
+
+.pf-focus-card {
+  min-width: 0;
+  padding: 28px 24px 36px 0;
+}
+
+.pf-focus-card + .pf-focus-card {
+  padding-left: 24px;
+  border-left: 1px solid var(--line);
+}
+
+.pf-focus-card h3 {
+  max-width: 240px;
+  margin: 0 0 20px;
+  color: var(--ink);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.pf-focus-card p {
+  max-width: 300px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.75;
+}
+
+/* Evidence */
+.pf-poc-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 48px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.pf-poc-card {
+  min-width: 0;
+  padding: 32px 28px 40px 0;
+}
+
+.pf-poc-card + .pf-poc-card {
+  padding-left: 28px;
+  border-left: 1px solid var(--line);
+}
+
+.pf-poc-card h4 {
+  margin: 0 0 18px;
+  color: var(--ink);
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.pf-poc-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.8;
+}
+
+/* Projects */
 .pf-project {
-  margin-bottom: 56px;
+  margin-bottom: 80px;
+  padding-top: 28px;
+  border-top: 1px solid var(--ink);
+}
+
+.pf-project:last-child {
+  margin-bottom: 0;
 }
 
 .pf-project-compact {
-  margin-bottom: 24px;
+  margin-bottom: 28px;
 }
 
 .pf-project-header {
   display: flex;
-  align-items: baseline;
-  gap: 12px;
-  margin-bottom: 8px;
   flex-wrap: wrap;
+  gap: 10px 18px;
+  align-items: baseline;
+  margin-bottom: 16px;
 }
 
-.pf-project h3 {
-  font-size: 20px;
-  font-weight: 800;
-  color: var(--text);
+.pf-project h3,
+.pf-service-card h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1.35;
 }
 
 .pf-project-link {
+  color: var(--blue);
   font-size: 13px;
-  color: var(--accent2);
+  font-weight: 700;
   text-decoration: none;
+  text-underline-offset: 4px;
 }
 
-.pf-project-link:hover { text-decoration: underline; }
+.pf-project-link:hover,
+.pf-project-link:focus-visible {
+  text-decoration: underline;
+}
 
 .pf-badge {
-  font-size: 11px;
-  font-weight: 600;
-  padding: 3px 10px;
-  border-radius: 6px;
-  letter-spacing: 0.02em;
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 2px 9px;
+  border: 1px solid currentColor;
+  border-radius: 2px;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  text-transform: uppercase;
 }
 
-.pf-badge-live { background: rgba(52,211,153,0.1); border: 1px solid rgba(52,211,153,0.25); color: var(--green); }
-.pf-badge-running { background: rgba(167,139,250,0.1); border: 1px solid rgba(167,139,250,0.25); color: var(--accent2); }
+.pf-badge-live {
+  color: var(--blue);
+}
+
+.pf-badge-running {
+  color: var(--blue);
+}
+
+.pf-section-dark .pf-badge-live {
+  color: var(--blue);
+}
 
 .pf-project-desc {
+  max-width: 800px;
+  margin: 0 0 28px;
+  color: var(--muted);
   font-size: 14px;
-  color: var(--text2);
-  margin-bottom: 16px;
-  line-height: 1.7;
+  line-height: 1.85;
 }
 
 .pf-detail {
-  background: var(--bg2);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 20px;
-  margin-bottom: 12px;
+  margin: 0;
+  padding: 22px 0;
+  border-top: 1px solid var(--line);
+}
+
+.pf-detail + .pf-detail {
+  margin-top: 0;
 }
 
 .pf-detail h4 {
-  font-size: 13px;
+  margin: 0 0 14px;
+  color: var(--blue);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 11px;
   font-weight: 700;
-  color: var(--accent2);
-  margin-bottom: 10px;
+  text-transform: uppercase;
 }
 
 .pf-detail ul {
-  list-style: none;
-  padding: 0;
+  display: grid;
+  gap: 8px;
   margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .pf-detail li {
-  font-size: 13px;
-  color: var(--text2);
-  line-height: 1.8;
-  padding-left: 16px;
   position: relative;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.75;
 }
 
 .pf-detail li::before {
-  content: '·';
   position: absolute;
+  top: 0.72em;
   left: 0;
-  color: var(--text3);
+  width: 6px;
+  height: 6px;
+  background: var(--blue);
+  content: "";
+}
+
+.pf-detail li strong {
+  color: var(--ink);
   font-weight: 700;
-}
-
-.pf-detail li strong { color: var(--text); font-weight: 600; }
-
-.pf-focus-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
-}
-
-.pf-focus-card {
-  background: var(--bg2);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 16px;
-}
-
-.pf-focus-card h3 {
-  font-size: 14px;
-  font-weight: 800;
-  color: var(--text);
-  margin-bottom: 8px;
-}
-
-.pf-focus-card p {
-  font-size: 12px;
-  color: var(--text2);
-  line-height: 1.65;
-  margin: 0;
 }
 
 .pf-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 12px;
+  gap: 7px;
+  margin-top: 20px;
 }
 
 .pf-chip {
-  background: var(--bg3);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 3px 10px;
-  font-size: 12px;
-  color: var(--text3);
+  padding: 4px 9px;
+  color: var(--muted);
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 10px;
 }
 
-.pf-service-grid {
+/* Featured public case */
+.pf-section-feature .pf-project {
   display: grid;
-  gap: 14px;
-}
-
-.pf-service-card {
-  display: grid;
-  grid-template-columns: 160px 1fr;
-  gap: 18px;
+  grid-template-columns: minmax(280px, 0.72fr) minmax(0, 1.28fr);
+  grid-template-areas:
+    "header media"
+    "description media"
+    "detail media"
+    "chips media";
+  gap: 0 52px;
   align-items: start;
-  background: var(--bg2);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 16px;
 }
 
-.pf-service-card img {
-  width: 100%;
-  aspect-ratio: 4 / 3;
-  object-fit: cover;
-  border-radius: 8px;
-  border: 1px solid var(--border);
-  display: block;
+.pf-section-feature .pf-project-header {
+  grid-area: header;
 }
 
-.pf-service-card h3 {
-  font-size: 16px;
-  font-weight: 800;
-  color: var(--text);
+.pf-section-feature .pf-project-desc {
+  grid-area: description;
 }
 
-.pf-service-card p {
-  font-size: 13px;
-  color: var(--text2);
-  line-height: 1.65;
-  margin: 8px 0 0;
+.pf-section-feature .pf-case-media {
+  grid-area: media;
 }
 
-/* ── SCREENSHOTS ── */
-.pf-screenshots {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 8px;
-  margin-top: 16px;
+.pf-section-feature .pf-detail {
+  grid-area: detail;
 }
 
-.pf-screenshots.pf-screenshots-2 {
-  grid-template-columns: repeat(2, 1fr);
-}
-
-.pf-screenshots.pf-screenshots-4 {
-  grid-template-columns: repeat(2, 1fr);
-}
-
-.pf-screenshot {
-  border-radius: 8px;
-  border: 1px solid var(--border);
-  width: 100%;
-  height: auto;
-  display: block;
-}
-
-.pf-screenshot-caption {
-  font-size: 11px;
-  color: var(--text3);
-  text-align: center;
-  margin-top: 4px;
+.pf-section-feature .pf-chips {
+  grid-area: chips;
 }
 
 .pf-case-media {
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(160px, 0.65fr);
-  gap: 12px;
+  grid-template-columns: minmax(0, 2.6fr) minmax(130px, 0.7fr);
+  gap: 14px;
   align-items: start;
-  margin: 20px 0;
+  margin: 0;
+  padding: 0 10px 10px;
+  overflow: hidden;
+  background: var(--terminal);
+  border: 1px solid var(--terminal);
+  border-radius: 4px;
+}
+
+.pf-terminal-panel-bar {
+  display: flex;
+  grid-column: 1 / -1;
+  justify-content: space-between;
+  align-items: center;
+  min-height: 38px;
+  margin: 0 -10px;
+  padding: 0 12px;
+  color: var(--terminal-muted);
+  border-bottom: 1px solid var(--terminal-line);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 10px;
 }
 
 .pf-case-media figure {
@@ -303,104 +662,1819 @@ body:has(.portfolio-root) > main {
   margin: 0;
 }
 
-@media (max-width: 600px) {
+.pf-screenshot {
+  display: block;
+  width: 100%;
+  height: auto;
+  border: 0;
+  border-radius: 2px;
+}
+
+.pf-screenshot-caption {
+  margin-top: 7px;
+  color: var(--terminal-muted);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 10px;
+  text-align: left;
+}
+
+.pf-screenshots {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.pf-screenshots.pf-screenshots-2,
+.pf-screenshots.pf-screenshots-4 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+/* Product experiments */
+.pf-service-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.pf-service-card {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-width: 0;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+
+.pf-service-card > img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  object-position: top center;
+  border-bottom: 1px solid var(--line);
+}
+
+.pf-service-card > div {
+  padding: 24px;
+}
+
+.pf-service-card h3 {
+  font-size: 20px;
+}
+
+.pf-service-card p {
+  margin: 12px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.75;
+}
+
+/* RAG diagram */
+.pf-section-dark svg rect {
+  fill: var(--soft);
+  stroke: var(--line);
+}
+
+.pf-section-dark svg text {
+  fill: var(--ink);
+}
+
+.pf-diagram {
+  margin: 28px 0;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+
+/* Writing index */
+.pf-blog-list {
+  border-top: 1px solid var(--ink);
+}
+
+.pf-blog-item {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.85fr) minmax(0, 1.15fr);
+  gap: 32px;
+  align-items: baseline;
+  padding: 20px 0;
+  color: inherit;
+  border-bottom: 1px solid var(--line);
+  text-decoration: none;
+  transition: color 160ms ease, padding 160ms ease;
+}
+
+.pf-blog-item:hover,
+.pf-blog-item:focus-visible {
+  padding-right: 12px;
+  padding-left: 12px;
+  color: var(--blue);
+}
+
+.pf-blog-title {
+  color: currentColor;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.pf-blog-desc {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+/* Footer */
+.pf-footer {
+  padding: 84px max(48px, calc((100% - 1280px) / 2));
+  background: var(--surface);
+  color: var(--muted);
+  border-top: 1px solid var(--ink);
+  text-align: left;
+}
+
+.pf-footer a {
+  color: var(--blue);
+  text-decoration: none;
+  text-underline-offset: 4px;
+}
+
+.pf-footer-name {
+  margin: 0 0 8px;
+  color: var(--ink);
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.pf-footer-copy {
+  max-width: 560px;
+  margin: 0 0 18px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.8;
+}
+
+.pf-footer a:hover,
+.pf-footer a:focus-visible {
+  text-decoration: underline;
+}
+
+@media (max-width: 980px) {
+  .pf-nav,
+  .pf-hero,
+  .pf-section,
+  .pf-footer {
+    padding-right: 32px;
+    padding-left: 32px;
+  }
+
+  .pf-hero h1 {
+    font-size: 68px;
+  }
+
+  .pf-hero-statement {
+    font-size: 40px;
+  }
+
+  .pf-hero-status {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .pf-hero-status p:last-child {
+    grid-column: 1 / -1;
+    padding-left: 0;
+    border-top: 1px solid var(--terminal-line);
+    border-left: 0;
+  }
+
+  .pf-hero-copy {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .pf-hero-copy p:last-child {
+    grid-column: 2;
+  }
+
+  .pf-section-title {
+    grid-template-columns: 112px minmax(0, 1fr);
+  }
+
+  .pf-section-lead {
+    margin-left: 136px;
+  }
+
+  .pf-section-feature .pf-project {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "header"
+      "description"
+      "media"
+      "detail"
+      "chips";
+    gap: 0;
+  }
+
+  .pf-section-feature .pf-case-media {
+    margin: 20px 0 28px;
+  }
+}
+
+@media (max-width: 720px) {
+  .pf-nav {
+    grid-template-columns: auto 1fr;
+    min-height: 56px;
+    padding: 0 20px;
+  }
+
+  .pf-nav-links {
+    justify-self: end;
+    gap: 18px;
+    font-size: 12px;
+  }
+
+  .pf-nav-contact {
+    display: none;
+  }
+
+  .pf-nav-brand-full {
+    display: none;
+  }
+
+  .pf-nav-brand-short {
+    display: inline;
+  }
+
+  .pf-hero {
+    min-height: 0;
+    padding: 48px 20px 52px;
+  }
+
+  .pf-hero-meta {
+    display: grid;
+    gap: 8px;
+    font-size: 10px;
+  }
+
+  .pf-hero-command {
+    margin-top: 52px;
+  }
+
+  .pf-hero h1 {
+    margin-top: 18px;
+    font-size: 52px;
+  }
+
+  .pf-hero-statement {
+    margin-top: 20px;
+    font-size: 30px;
+    line-height: 1.3;
+  }
+
+  .pf-break-mobile {
+    display: initial;
+  }
+
+  .pf-break-desktop {
+    display: none;
+  }
+
+  .pf-hero-copy {
+    grid-template-columns: 1fr;
+    gap: 18px;
+    margin-top: 40px;
+  }
+
+  .pf-hero-copy p:last-child {
+    grid-column: auto;
+  }
+
+  .pf-hero-status {
+    grid-template-columns: 1fr;
+    margin-top: 36px;
+  }
+
+  .pf-hero-status p,
+  .pf-hero-status p + p,
+  .pf-hero-status p:last-child {
+    grid-column: auto;
+    padding: 14px 0 16px;
+    border-top: 1px solid var(--terminal-line);
+    border-left: 0;
+  }
+
+  .pf-hero-status p:first-child {
+    border-top: 0;
+  }
+
+  .pf-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .pf-metrics > div {
+    padding: 24px 20px;
+  }
+
+  .pf-metrics > div:nth-child(odd) {
+    border-left: 0;
+  }
+
+  .pf-metrics > div:nth-child(n + 3) {
+    border-top: 1px solid var(--terminal-line);
+  }
+
+  .pf-metrics strong {
+    font-size: 28px;
+  }
+
+  .pf-section,
+  .pf-footer {
+    padding: 72px 20px;
+    scroll-margin-top: 56px;
+  }
+
+  .pf-section-compact {
+    padding-top: 56px;
+    padding-bottom: 56px;
+  }
+
+  .pf-section-title {
+    grid-template-columns: 1fr;
+    gap: 10px;
+    margin-bottom: 38px;
+    font-size: 28px;
+  }
+
+  .pf-section-title > span {
+    padding-top: 0;
+  }
+
+  .pf-section-lead {
+    margin: -16px 0 36px;
+    font-size: 14px;
+  }
+
+  .pf-focus-grid,
+  .pf-poc-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .pf-focus-card,
+  .pf-poc-card {
+    padding: 24px 0;
+  }
+
+  .pf-focus-card + .pf-focus-card,
+  .pf-poc-card + .pf-poc-card {
+    padding-left: 0;
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+
+  .pf-focus-card h3,
+  .pf-focus-card p {
+    max-width: none;
+  }
+
+  .pf-project {
+    margin-bottom: 60px;
+  }
+
+  .pf-project-header {
+    align-items: flex-start;
+  }
+
+  .pf-project h3 {
+    width: 100%;
+    font-size: 22px;
+  }
+
+  .pf-case-media,
   .pf-screenshots,
   .pf-screenshots.pf-screenshots-2,
   .pf-screenshots.pf-screenshots-4 {
     grid-template-columns: 1fr;
   }
 
-  .pf-case-media {
+  .pf-case-media figure:last-child {
+    width: min(100%, 280px);
+  }
+
+  .pf-terminal-panel-bar {
+    font-size: 9px;
+  }
+
+  .pf-service-grid {
     grid-template-columns: 1fr;
   }
 
-  .pf-case-media figure:last-child {
-    width: min(100%, 320px);
-    margin: 0 auto;
+  .pf-service-card > div {
+    padding: 20px;
+  }
+
+  .pf-blog-item {
+    grid-template-columns: 1fr;
+    gap: 6px;
+    padding: 18px 0;
+  }
+
+  .pf-blog-item:hover,
+  .pf-blog-item:focus-visible {
+    padding-right: 0;
+    padding-left: 0;
   }
 }
 
-/* ── POC GRID ── */
-.pf-poc-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 12px;
+@media (max-width: 360px) {
+  .pf-hero-statement {
+    font-size: 28px;
+  }
 }
 
-.pf-poc-card {
-  background: var(--bg2);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 16px;
+/* Typography legibility pass */
+.portfolio-root {
+  --muted: #4f5755;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-.pf-poc-card h4 {
-  font-size: 14px;
-  font-weight: 700;
-  margin-bottom: 6px;
-  color: var(--text);
-}
-
-.pf-poc-card p {
+.pf-appbar {
   font-size: 12px;
-  color: var(--text3);
-  line-height: 1.6;
-  margin: 0;
 }
 
-/* ── BLOG LINKS ── */
-.pf-blog-list {
+.pf-nav-label {
+  color: #69716f;
+  font-size: 10px;
+}
+
+.pf-nav-links {
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.pf-nav-links a > span {
+  font-size: 10px;
+}
+
+.pf-nav-runtime,
+.pf-nav-contact {
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.pf-hero-meta {
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.pf-hero-command {
+  font-size: 15px;
+}
+
+.pf-hero-status span {
+  font-size: 11px;
+}
+
+.pf-hero-status strong {
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.pf-readme-header {
+  font-size: 10px;
+}
+
+.pf-hero-copy p {
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.85;
+}
+
+.pf-hero-copy p::before {
+  font-size: 11px;
+}
+
+.pf-scroll-link {
+  font-size: 14px;
+}
+
+.pf-metrics .pf-metric-path {
+  font-size: 11px;
+}
+
+.pf-metrics span {
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.pf-section-title > span {
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+/* Final CLI layout priority */
+.pf-workspace {
+  display: block;
+  min-height: 100vh;
+  padding-bottom: 32px;
+  background: var(--paper);
+}
+
+.pf-cli-header {
+  width: 100%;
+  column-gap: 36px;
+}
+
+.pf-main {
+  grid-area: auto;
+  width: min(100%, 1200px);
+  margin: 0 auto;
+  background: var(--paper);
+}
+
+.pf-statusbar {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 60;
+  height: 32px;
+  background: var(--surface);
+  color: var(--muted);
+  border-top: 1px solid var(--blue);
+}
+
+.pf-statusbar i {
+  background: var(--blue);
+}
+
+@media (max-width: 900px) {
+  .pf-workspace {
+    display: block;
+    padding-bottom: 32px;
+  }
+
+  .pf-main {
+    grid-row: auto;
+    width: 100%;
+  }
+}
+
+@media (max-width: 520px) {
+  .pf-cli-status {
+    width: 7px;
+    max-width: none;
+    gap: 0;
+    overflow: visible;
+    font-size: 0;
+  }
+}
+
+/* Full-page CLI theme */
+body:has(.portfolio-root) {
+  background: #090b0f !important;
+}
+
+.portfolio-root {
+  --paper: #090b0f;
+  --surface: #0d1015;
+  --soft: #11151b;
+  --ink: #edf1fa;
+  --muted: #a4afc0;
+  --line: #2c3442;
+  --blue: #86a5ff;
+  --terminal: #090b0f;
+  --terminal-line: #2c3442;
+  --terminal-muted: #a4afc0;
+  --blue-on-dark: #86a5ff;
+
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.pf-workspace {
+  display: block;
+  min-height: 100vh;
+  padding-bottom: 32px;
+  background: var(--paper);
+}
+
+.pf-cli-header {
+  position: sticky;
+  z-index: 50;
+  top: 0;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  min-height: 64px;
+  padding: 0 40px;
+  background: rgba(9, 11, 15, 0.96);
+  border-bottom: 1px solid var(--blue);
+  font-family: var(--font-geist-mono), monospace;
+}
+
+.pf-cli-brand,
+.pf-cli-nav a {
+  text-decoration: none;
+}
+
+.pf-cli-brand {
+  justify-self: start;
+  color: var(--blue);
+  font-size: 15px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.pf-cli-brand > span {
+  margin-right: 8px;
+}
+
+.pf-cli-nav {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  gap: 28px;
+}
+
+.pf-cli-nav a {
+  color: #bcc6d7;
+  font-size: 13px;
+  text-underline-offset: 5px;
+}
+
+.pf-cli-nav a:hover,
+.pf-cli-nav a:focus-visible {
+  color: var(--blue);
+  text-decoration: underline;
+}
+
+.pf-cli-status {
+  display: inline-flex;
+  justify-self: end;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.pf-cli-status i {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  background: var(--blue);
+  border-radius: 50%;
+}
+
+.pf-main {
+  width: min(100%, 1200px);
+  margin: 0 auto;
+  background: var(--paper);
+}
+
+.pf-hero {
+  display: block;
+  min-height: 0;
+  padding: 76px 40px 68px;
+  background: var(--paper);
+  color: var(--ink);
+  border-bottom: 1px solid var(--line);
+  scroll-margin-top: 64px;
+}
+
+.pf-hero-meta {
+  color: var(--muted);
+  font-family: var(--font-geist-mono), monospace;
+}
+
+.pf-hero-meta i,
+.pf-terminal-panel-bar i {
+  background: var(--blue);
+}
+
+.pf-hero-command {
+  display: flex;
+  align-items: center;
+  min-height: 0;
+  margin: 56px 0 0;
+  padding: 0;
+  background: transparent;
+  color: #c4cede;
+  border: 0;
+  font-family: var(--font-geist-mono), monospace;
+}
+
+.pf-hero-command span {
+  color: var(--blue);
+}
+
+.pf-hero h1 {
+  margin: 24px 0 0;
+  color: var(--blue);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 78px;
+  font-weight: 600;
+  line-height: 1.05;
+}
+
+.pf-hero-statement {
+  max-width: 820px;
+  margin-top: 30px;
+  color: var(--ink);
+  font-size: 42px;
+  line-height: 1.32;
+}
+
+.pf-hero-status {
+  margin-top: 48px;
+  background: var(--surface);
+  border-color: var(--line);
+}
+
+.pf-hero-status p + p {
+  border-color: var(--line);
+}
+
+.pf-hero-status span {
+  color: var(--blue);
+}
+
+.pf-hero-status strong {
+  color: var(--ink);
+}
+
+.pf-scroll-link {
+  margin-top: 34px;
+  color: var(--blue);
+  font-family: var(--font-geist-mono), monospace;
+}
+
+.pf-readme-output {
+  padding: 40px;
+  background: var(--paper);
+  border-bottom: 1px solid var(--line);
+}
+
+.pf-readme-header,
+.pf-terminal-panel-bar {
+  background: var(--surface);
+  color: var(--muted);
+  border-color: var(--line);
+}
+
+.pf-readme-output .pf-hero-copy {
+  margin-top: 28px;
+}
+
+.pf-hero-copy p {
+  color: var(--muted);
+}
+
+.pf-hero-copy p::before {
+  color: var(--blue);
+}
+
+.pf-metrics {
+  margin: 0 40px;
+  background: var(--surface);
+  border-color: var(--line);
+}
+
+.pf-metrics > div + div {
+  border-color: var(--line);
+}
+
+.pf-metrics .pf-metric-path {
+  color: var(--blue);
+}
+
+.pf-metrics strong {
+  color: var(--ink);
+}
+
+.pf-metrics span {
+  color: var(--muted);
+}
+
+.pf-section,
+.pf-section-tinted,
+.pf-section-dark,
+.pf-section-feature,
+.pf-section-compact {
+  padding: 88px 40px;
+  background: var(--paper);
+  color: var(--ink);
+  border-color: var(--line);
+  scroll-margin-top: 64px;
+}
+
+.pf-section-feature {
+  border-top: 0;
+}
+
+.pf-section-title {
+  display: grid;
+  grid-template-columns: 1fr;
   gap: 12px;
+  margin-bottom: 42px;
+  color: var(--ink);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 32px;
+}
+
+.pf-section-title > span,
+.pf-section-dark .pf-section-title > span,
+.pf-section-compact .pf-section-title > span {
+  padding-top: 0;
+  color: var(--blue);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.pf-section-lead {
+  max-width: 900px;
+  margin: 0 0 48px;
+  color: var(--muted);
+}
+
+.pf-focus-grid,
+.pf-poc-grid,
+.pf-blog-list {
+  border-color: var(--line);
+}
+
+.pf-focus-card + .pf-focus-card,
+.pf-poc-card + .pf-poc-card {
+  border-color: var(--line);
+}
+
+.pf-focus-card h3,
+.pf-poc-card h4,
+.pf-project h3,
+.pf-service-card h3 {
+  color: var(--ink);
+}
+
+.pf-focus-card p,
+.pf-poc-card p,
+.pf-project-desc,
+.pf-detail li,
+.pf-service-card p,
+.pf-blog-desc {
+  color: var(--muted);
+}
+
+.pf-project {
+  border-color: var(--line);
+}
+
+.pf-project-link,
+.pf-detail h4,
+.pf-blog-item:hover,
+.pf-blog-item:focus-visible {
+  color: var(--blue);
+}
+
+.pf-badge,
+.pf-badge-live,
+.pf-badge-running,
+.pf-section-dark .pf-badge-live {
+  color: var(--blue);
+}
+
+.pf-detail {
+  border-color: var(--line);
+}
+
+.pf-detail li strong {
+  color: var(--ink);
+}
+
+.pf-detail li::before {
+  background: var(--blue);
+}
+
+.pf-chip {
+  background: var(--surface);
+  color: #c2ccdc;
+  border-color: var(--line);
+}
+
+.pf-case-media {
+  background: var(--surface);
+  border-color: rgba(134, 165, 255, 0.48);
+}
+
+.pf-screenshot-caption {
+  color: var(--muted);
+}
+
+.pf-service-card {
+  background: var(--surface);
+  border-color: var(--line);
+}
+
+.pf-service-card > img {
+  border-color: var(--line);
+}
+
+.pf-section-dark svg rect {
+  fill: var(--surface);
+  stroke: var(--line);
+}
+
+.pf-section-dark svg text {
+  fill: var(--ink);
+}
+
+.pf-diagram {
+  background: var(--surface);
+  border-color: var(--line);
 }
 
 .pf-blog-item {
-  display: block;
-  padding: 16px 20px;
-  background: var(--bg2);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  text-decoration: none;
-  transition: border-color 0.2s;
+  color: var(--ink);
+  border-color: var(--line);
 }
-
-.pf-blog-item:hover { border-color: var(--accent); }
 
 .pf-blog-title {
-  font-size: 14px;
-  font-weight: 700;
-  color: var(--text);
-  margin-bottom: 2px;
+  color: currentColor;
 }
 
-.pf-blog-desc {
-  font-size: 12px;
-  color: var(--text3);
+@media (min-width: 901px) {
+  #workflow .pf-project {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0 36px;
+    align-items: start;
+  }
+
+  #workflow .pf-project-header,
+  #workflow .pf-project-desc,
+  #workflow .pf-chips {
+    grid-column: 1 / -1;
+  }
+
+  #workflow .pf-detail {
+    min-width: 0;
+  }
 }
 
-/* ── FOOTER ── */
 .pf-footer {
-  text-align: center;
-  padding: 60px 24px;
-  color: var(--text3);
-  font-size: 13px;
-  border-top: 1px solid var(--border);
-  max-width: 800px;
-  margin: 0 auto;
+  padding: 68px 40px 76px;
+  background: var(--surface);
+  color: var(--muted);
+  border-color: var(--line);
+}
+
+.pf-footer-name {
+  color: var(--ink);
+  font-family: var(--font-geist-mono), monospace;
+}
+
+.pf-footer-copy {
+  color: var(--muted);
 }
 
 .pf-footer a {
-  color: var(--accent2);
-  text-decoration: none;
+  color: var(--blue);
 }
 
-.pf-footer a:hover { text-decoration: underline; }
+.pf-statusbar {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 60;
+  height: 32px;
+  background: var(--surface);
+  color: var(--muted);
+  border-top: 1px solid var(--blue);
+}
 
-/* ── RESPONSIVE ── */
-@media (max-width: 600px) {
-  .pf-project-header { flex-direction: column; gap: 6px; }
-  .pf-focus-grid { grid-template-columns: 1fr; }
-  .pf-service-card { grid-template-columns: 1fr; }
-  .pf-poc-grid { grid-template-columns: 1fr; }
+.pf-statusbar i {
+  background: var(--blue);
+}
+
+@media (max-width: 900px) {
+  .pf-cli-header {
+    grid-template-columns: 1fr auto;
+    min-height: 98px;
+    padding: 0 20px;
+  }
+
+  .pf-cli-brand {
+    font-size: 13px;
+  }
+
+  .pf-cli-nav {
+    grid-row: 2;
+    grid-column: 1 / -1;
+    gap: 22px;
+    width: 100%;
+    padding: 13px 0;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+
+  .pf-cli-nav a {
+    flex: none;
+    font-size: 12px;
+  }
+
+  .pf-cli-status {
+    font-size: 10px;
+  }
+
+  .pf-hero,
+  .pf-section,
+  .pf-readme-output,
+  .pf-footer {
+    scroll-margin-top: 98px;
+  }
+
+  .pf-hero {
+    padding: 52px 20px 48px;
+  }
+
+  .pf-hero-command {
+    margin-top: 38px;
+  }
+
+  .pf-hero h1 {
+    font-size: 54px;
+  }
+
+  .pf-hero-statement {
+    font-size: 30px;
+  }
+
+  .pf-readme-output,
+  .pf-section,
+  .pf-footer {
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+
+  .pf-readme-output {
+    padding-top: 32px;
+    padding-bottom: 34px;
+  }
+
+  .pf-metrics {
+    margin-right: 20px;
+    margin-left: 20px;
+  }
+
+  .pf-section {
+    padding-top: 68px;
+    padding-bottom: 68px;
+  }
+
+  .pf-section-title {
+    font-size: 27px;
+  }
+
+  .pf-section-title > span,
+  .pf-section-dark .pf-section-title > span,
+  .pf-section-compact .pf-section-title > span {
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 520px) {
+  .pf-cli-status {
+    width: 7px;
+    max-width: none;
+    gap: 0;
+    overflow: visible;
+    font-size: 0;
+  }
+
+  .pf-hero h1 {
+    font-size: 46px;
+  }
+
+  .pf-hero-statement {
+    font-size: 28px;
+  }
+
+  .pf-statusbar span:nth-child(2),
+  .pf-statusbar span:nth-child(3) {
+    display: none;
+  }
+}
+
+.pf-section-lead {
+  color: var(--muted);
+  font-size: 16px;
+  line-height: 1.9;
+}
+
+.pf-focus-card h3,
+.pf-poc-card h4 {
+  font-size: 19px;
+}
+
+.pf-focus-card p,
+.pf-poc-card p {
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.85;
+}
+
+.pf-project-link {
+  font-size: 14px;
+}
+
+.pf-badge {
+  font-size: 11px;
+}
+
+.pf-project-desc {
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.9;
+}
+
+.pf-detail h4 {
+  font-size: 12px;
+}
+
+.pf-detail li {
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.85;
+}
+
+.pf-chip,
+.pf-screenshot-caption,
+.pf-terminal-panel-bar {
+  font-size: 11px;
+}
+
+.pf-service-card h3 {
+  font-size: 21px;
+}
+
+.pf-service-card p {
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.85;
+}
+
+.pf-blog-title {
+  font-size: 16px;
+}
+
+.pf-blog-desc {
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.pf-footer-copy {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.pf-statusbar {
+  font-size: 10px;
+}
+
+@media (max-width: 860px) {
+  .pf-section-lead {
+    font-size: 15px;
+    line-height: 1.85;
+  }
+
+  .pf-hero-copy p,
+  .pf-project-desc,
+  .pf-detail li,
+  .pf-service-card p,
+  .pf-blog-desc {
+    font-size: 15px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pf-nav-links a::after,
+  .pf-nav-contact::after,
+  .pf-blog-item {
+    transition: none;
+  }
+}
+
+/* Codex workspace shell */
+body:has(.portfolio-root) {
+  background: var(--soft, #f4f6f7) !important;
+}
+
+.portfolio-root {
+  overflow: visible;
+  background: var(--soft);
+}
+
+.pf-workspace {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  grid-template-rows: 48px minmax(0, auto) 28px;
+  grid-template-areas:
+    "appbar appbar"
+    "sidebar main"
+    "status status";
+  min-height: 100vh;
+  background: var(--surface);
+}
+
+.pf-appbar {
+  position: sticky;
+  z-index: 40;
+  top: 0;
+  display: flex;
+  grid-area: appbar;
+  justify-content: space-between;
+  align-items: center;
+  min-width: 0;
+  height: 48px;
+  padding: 0 14px;
+  background: #f7f8f9;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 11px;
+}
+
+.pf-appbar-product,
+.pf-appbar-context {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.pf-appbar-product strong {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.pf-appbar-mark {
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  background: var(--ink);
+  color: #ffffff;
+  border-radius: 3px;
+  font-weight: 700;
+}
+
+.pf-appbar-context span:last-child,
+.pf-nav-runtime span:first-of-type,
+.pf-statusbar span:first-child {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.pf-appbar-context i,
+.pf-nav-runtime i,
+.pf-statusbar i {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background: var(--blue);
+  border-radius: 50%;
+}
+
+.pf-nav {
+  position: sticky;
+  z-index: 20;
+  top: 48px;
+  display: flex;
+  grid-area: sidebar;
+  flex-direction: column;
+  align-self: start;
+  width: auto;
+  height: calc(100vh - 76px);
+  min-height: 0;
+  padding: 20px 12px;
+  overflow-y: auto;
+  background: var(--soft);
+  border-right: 1px solid var(--line);
+  border-bottom: 0;
+  backdrop-filter: none;
+}
+
+.pf-nav a {
+  color: var(--ink);
+}
+
+.pf-nav-brand {
+  align-self: stretch;
+  justify-self: auto;
+  padding: 7px 10px;
+  color: var(--ink) !important;
+  font-size: 12px;
+}
+
+.pf-nav-label {
+  margin: 18px 10px 7px;
+  color: #7a8280;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em !important;
+}
+
+.pf-nav-links {
+  display: grid;
+  gap: 2px;
+  width: 100%;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 11px;
+}
+
+.pf-nav-links a {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 6px;
+  align-items: center;
+  min-width: 0;
+  padding: 7px 10px;
+  border-radius: 3px;
+}
+
+.pf-nav-links a:hover,
+.pf-nav-links a:focus-visible {
+  background: #e6eaed;
+  color: var(--blue);
+  outline: none;
+}
+
+.pf-nav-links a::after,
+.pf-nav-contact::after {
+  display: none;
+}
+
+.pf-nav-links a > span {
+  color: #88908e;
+  font-size: 9px;
+}
+
+.pf-nav-runtime {
+  display: grid;
+  gap: 5px;
+  margin-top: auto;
+  padding: 0 10px 16px;
+  color: var(--muted);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 10px;
+}
+
+.pf-nav-runtime .pf-nav-label {
+  margin: 18px 0 5px;
+}
+
+.pf-nav-contact {
+  align-self: stretch;
+  justify-self: auto;
+  padding: 8px 10px;
+  color: var(--blue) !important;
+  border-top: 1px solid var(--line);
+  font-size: 10px;
+}
+
+.pf-main {
+  grid-area: main;
+  min-width: 0;
+  background: var(--surface);
+}
+
+.pf-hero {
+  display: block;
+  min-height: 0;
+  padding: 54px clamp(32px, 5vw, 72px) 60px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+  color: var(--ink);
+  scroll-margin-top: 48px;
+}
+
+.pf-hero-meta {
+  color: var(--muted);
+}
+
+.pf-hero-meta i {
+  background: var(--blue);
+}
+
+.pf-hero-command {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 44px;
+  margin: 34px 0 0;
+  padding: 0 14px;
+  background: var(--terminal);
+  color: #d9dddc;
+  border: 1px solid var(--terminal);
+  border-radius: 4px;
+}
+
+.pf-hero-command span {
+  color: var(--blue-on-dark);
+}
+
+.pf-hero h1 {
+  margin-top: 44px;
+  color: var(--ink);
+  font-size: 76px;
+}
+
+.pf-hero-statement {
+  max-width: 820px;
+  color: var(--ink);
+  font-size: 42px;
+}
+
+.pf-hero-status {
+  margin-top: 42px;
+  border-color: var(--line);
+}
+
+.pf-hero-status p + p {
+  border-color: var(--line);
+}
+
+.pf-hero-status span {
+  color: var(--blue);
+}
+
+.pf-hero-status strong {
+  color: var(--ink);
+}
+
+.pf-hero-copy {
+  margin-top: 34px;
+}
+
+.pf-hero-copy p {
+  color: var(--muted);
+}
+
+.pf-hero-copy p::before {
+  color: #8a9290;
+}
+
+.pf-scroll-link {
+  color: var(--blue);
+}
+
+.pf-readme-output {
+  padding: 0 clamp(32px, 5vw, 72px) 42px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+}
+
+.pf-readme-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 12px;
+  background: var(--soft);
+  color: var(--muted);
+  border: 1px solid var(--line);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 9px;
+}
+
+.pf-readme-output .pf-hero-copy {
+  margin-top: 26px;
+}
+
+.pf-metrics {
+  background: var(--soft);
+  border-color: var(--line);
+}
+
+.pf-metrics > div {
+  padding: 24px clamp(20px, 3vw, 32px);
+}
+
+.pf-metrics > div + div {
+  border-color: var(--line);
+}
+
+.pf-metrics strong {
+  color: var(--ink);
+  font-size: 32px;
+}
+
+.pf-metrics span {
+  color: var(--muted);
+}
+
+.pf-metrics .pf-metric-path {
+  color: var(--blue);
+}
+
+.pf-section,
+.pf-footer {
+  padding-right: clamp(32px, 5vw, 72px);
+  padding-left: clamp(32px, 5vw, 72px);
+  scroll-margin-top: 48px;
+}
+
+.pf-section {
+  padding-top: 78px;
+  padding-bottom: 78px;
+}
+
+.pf-section-feature {
+  border-top-width: 1px;
+}
+
+.pf-section-title {
+  grid-template-columns: 150px minmax(0, 1fr);
+  margin-bottom: 46px;
+  font-size: 32px;
+}
+
+.pf-section-title > span {
+  padding-top: 7px;
+  font-size: 10px;
+}
+
+.pf-section-lead {
+  margin-left: 174px;
+}
+
+.pf-footer {
+  padding-top: 64px;
+  padding-bottom: 72px;
+}
+
+.pf-statusbar {
+  position: sticky;
+  z-index: 50;
+  bottom: 0;
+  display: flex;
+  grid-area: status;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 20px;
+  height: 28px;
+  padding: 0 12px;
+  background: #f7f8f9;
+  color: var(--muted);
+  border-top: 1px solid var(--line);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 9px;
+}
+
+.pf-statusbar span:first-child {
+  margin-right: auto;
+}
+
+.pf-statusbar i {
+  background: var(--blue);
+}
+
+@media (max-width: 860px) {
+  .pf-workspace {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: 44px 44px minmax(0, auto) 26px;
+    grid-template-areas:
+      "appbar"
+      "sidebar"
+      "main"
+      "status";
+  }
+
+  .pf-appbar {
+    height: 44px;
+  }
+
+  .pf-appbar-context > span:first-child {
+    display: none;
+  }
+
+  .pf-nav {
+    top: 44px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+    height: 44px;
+    padding: 0 12px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    background: #f7f8f9;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .pf-nav-brand,
+  .pf-nav > .pf-nav-label,
+  .pf-nav-runtime,
+  .pf-nav-contact {
+    display: none;
+  }
+
+  .pf-nav-links {
+    display: flex;
+    flex: none;
+    gap: 3px;
+    width: auto;
+    white-space: nowrap;
+  }
+
+  .pf-nav-links a {
+    display: inline-flex;
+    grid-template-columns: none;
+    flex: none;
+    gap: 5px;
+    padding: 7px 9px;
+  }
+
+  .pf-main {
+    grid-row: auto;
+  }
+
+  .pf-hero,
+  .pf-section,
+  .pf-footer,
+  .pf-readme-output {
+    scroll-margin-top: 88px;
+  }
+
+  .pf-hero {
+    padding: 38px 20px 48px;
+  }
+
+  .pf-hero-meta {
+    display: grid;
+  }
+
+  .pf-hero-command {
+    margin-top: 28px;
+  }
+
+  .pf-hero h1 {
+    margin-top: 38px;
+    font-size: 52px;
+  }
+
+  .pf-hero-statement {
+    font-size: 30px;
+  }
+
+  .pf-hero-status {
+    margin-top: 34px;
+  }
+
+  .pf-hero-status p,
+  .pf-hero-status p + p,
+  .pf-hero-status p:last-child {
+    border-color: var(--line);
+  }
+
+  .pf-metrics > div:nth-child(n + 3) {
+    border-color: var(--line);
+  }
+
+  .pf-section,
+  .pf-footer,
+  .pf-readme-output {
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+
+  .pf-readme-output {
+    padding-bottom: 34px;
+  }
+
+  .pf-readme-output .pf-hero-copy {
+    margin-top: 22px;
+  }
+
+  .pf-section {
+    padding-top: 64px;
+    padding-bottom: 64px;
+  }
+
+  .pf-section-title {
+    grid-template-columns: 1fr;
+    font-size: 28px;
+  }
+
+  .pf-section-lead {
+    margin-left: 0;
+  }
+
+  .pf-statusbar {
+    height: 26px;
+    gap: 12px;
+  }
+
+  .pf-statusbar span:nth-child(2),
+  .pf-statusbar span:nth-child(3) {
+    display: none;
+  }
+}
+
+@media (max-width: 360px) {
+  .pf-appbar-product > span:last-child,
+  .pf-statusbar span:last-child {
+    display: none;
+  }
+
+  .pf-hero-statement {
+    font-size: 28px;
+  }
+}
+
+/* Workspace chrome must remain legible after shell overrides. */
+.pf-appbar {
+  font-size: 12px;
+}
+
+.pf-nav-label {
+  color: #69716f;
+  font-size: 10px;
+}
+
+.pf-nav-links {
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.pf-nav-links a > span {
+  font-size: 10px;
+}
+
+.pf-nav-runtime,
+.pf-nav-contact {
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.pf-readme-header,
+.pf-section-title > span,
+.pf-statusbar {
+  font-size: 10px;
+}
+
+.pf-section-title > span {
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+/* Final CLI layout priority */
+.pf-workspace {
+  display: block;
+  min-height: 100vh;
+  padding-bottom: 32px;
+  background: var(--paper);
+}
+
+.pf-cli-header {
+  width: 100%;
+  column-gap: 36px;
+}
+
+.pf-main {
+  grid-area: auto;
+  width: min(100%, 1200px);
+  margin: 0 auto;
+  background: var(--paper);
+}
+
+.pf-statusbar {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 60;
+  height: 32px;
+  background: var(--surface);
+  color: var(--muted);
+  border-top: 1px solid var(--blue);
+}
+
+.pf-statusbar i {
+  background: var(--blue);
+}
+
+@media (max-width: 900px) {
+  .pf-workspace {
+    display: block;
+    padding-bottom: 32px;
+  }
+
+  .pf-main {
+    grid-row: auto;
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## 변경 사항

- 포트폴리오 전체를 다크 CLI 세션 형태로 재구성했습니다.
- 상단 명령형 내비게이션과 하단 상태 바를 추가했습니다.
- 실무 경험을 개인 프로젝트보다 먼저 배치하고 KS UI 대표 이미지를 artifact 패널로 확대했습니다.
- 포인트 색상을 `#86a5ff` 하나로 통일했습니다.
- 320px, 390px, 1440px 반응형 레이아웃을 정리했습니다.

## 목적

채용담당자가 실무 UI 운영 경험과 공개 구현 사례를 빠르게 파악하면서도, UI/Frontend 개발자 포트폴리오라는 인상을 명확하게 받을 수 있도록 정보 위계와 시각 언어를 통일했습니다.

## 검증

- `npx tsc --noEmit --pretty false`
- `npm run lint -- src/app/portfolio/page.tsx` (오류 0건, 기존 `img` 경고 6건)
- 320px, 390px, 1440px 가로 넘침 및 주요 항목 겹침 0건
- 로컬 `/portfolio` 확인 완료

## 배포

- 로컬 `next build`는 실행하지 않습니다.
- Vercel 원격 프로덕션 배포로 검증합니다.
